### PR TITLE
Add more type annotations to base_envs and enable mypy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,6 +76,10 @@ jobs:
           name: pytype
           command: pytype ${TYPECHECK_FILES}
 
+      - run:
+          name: mypy
+          command: mypy ${TYPECHECK_FILES}
+
   unit-test:
     executor: my-executor
     parallelism: 3

--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # If you change these, also change .circleci/config.yml.
-SRC_FILES=(src/ tests/ experiments/ setup.py)
+SRC_FILES=(src/ tests/ setup.py)
 
 set -x  # echo commands
 set -e  # quit immediately on error
@@ -24,4 +24,5 @@ if [ "$skipexpensive" != "true" ]; then
 
   echo "Type checking"
   pytype ${SRC_FILES[@]}
+  mypy ${SRC_FILES[@]}
 fi

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,13 @@ inputs =
 	setup.py
 python_version = 3.7
 
+[mypy-gym.*]
+ignore_missing_imports = True
+[mypy-numpy.*]
+ignore_missing_imports = True
+[mypy-pytest.*]
+ignore_missing_imports = True
+
 [tool:pytest]
 markers =
     expensive: mark a test as expensive (deselect with '-m "not expensive"')

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 import os
 import sys
 
-from setuptools import find_packages, setup
+from setuptools import find_packages, setup  # type:ignore
 
 
 def get_version() -> str:
@@ -14,7 +14,7 @@ def get_version() -> str:
     sys.path.insert(
         0, os.path.join(os.path.dirname(__file__), "src", "seals"),
     )
-    from version import VERSION  # pytype:disable=import-error
+    from version import VERSION  # type:ignore
 
     del sys.path[0]
     return VERSION
@@ -40,6 +40,7 @@ TESTS_REQUIRE = [
     "flake8-debugger",
     "flake8-docstrings",
     "flake8-isort",
+    "mypy",
     "pydocstyle",
     "pytest",
     "pytest-cov",

--- a/src/seals/base_envs.py
+++ b/src/seals/base_envs.py
@@ -73,7 +73,7 @@ class ResettablePOMDP(gym.Env, abc.ABC, Generic[State, Observation, Action]):
     @property
     def observation_space(self) -> gym.Space:
         """Observation space. Return type of reset() and component of step()."""
-        return self.state_space
+        return self._observation_space
 
     @property
     def action_space(self) -> gym.Space:

--- a/src/seals/base_envs.py
+++ b/src/seals/base_envs.py
@@ -1,7 +1,7 @@
 """Base environment classes."""
 
 import abc
-from typing import Optional, Sequence
+from typing import Generic, Optional, Sequence, Tuple, TypeVar, cast
 
 import gym
 from gym import spaces
@@ -9,8 +9,12 @@ import numpy as np
 
 from seals import util
 
+State = TypeVar("State")
+Observation = TypeVar("Observation")
+Action = TypeVar("Action")
 
-class ResettableEnv(gym.Env, abc.ABC):
+
+class ResettableEnv(gym.Env, abc.ABC, Generic[State, Observation, Action]):
     """ABC for environments that are resettable.
 
     Specifically, these environments provide oracle access to sample from
@@ -40,29 +44,34 @@ class ResettableEnv(gym.Env, abc.ABC):
         self._observation_space = observation_space
         self._action_space = action_space
 
-        self.cur_state = None
-        self._n_actions_taken = None
+        self.cur_state: Optional[State] = None
+        self._n_actions_taken: Optional[int] = None
         self.seed()
 
     @abc.abstractmethod
-    def initial_state(self):
+    def initial_state(self) -> State:
         """Samples from the initial state distribution."""
 
     @abc.abstractmethod
-    def transition(self, state, action):
+    def transition(self, state: State, action: Action) -> State:
         """Samples from transition distribution."""
 
     @abc.abstractmethod
-    def reward(self, state, action, new_state) -> float:
+    def reward(self, state: State, action: Action, new_state: State) -> float:
         """Computes reward for a given transition."""
 
     @abc.abstractmethod
-    def terminal(self, state, step: int) -> bool:
+    def terminal(self, state: State, step: int) -> bool:
         """Is the state terminal?"""
 
-    def obs_from_state(self, state):
-        """Returns observation produced by a given state."""
-        return state
+    def obs_from_state(self, state: State) -> Observation:
+        """Returns observation produced by a given state.
+
+        Default implementation is identity, suitable for MDPs;
+        must be overridden for POMDP subclasses.
+        """
+        assert self.state_space == self.observation_space
+        return cast(state, Observation)
 
     @property
     def state_space(self) -> gym.Space:
@@ -82,6 +91,7 @@ class ResettableEnv(gym.Env, abc.ABC):
     @property
     def n_actions_taken(self) -> int:
         """Number of steps taken so far."""
+        assert self._n_actions_taken is not None
         return self._n_actions_taken
 
     def seed(self, seed=None) -> Sequence[int]:
@@ -93,14 +103,14 @@ class ResettableEnv(gym.Env, abc.ABC):
         self.rand_state = np.random.RandomState(seed)
         return [seed]
 
-    def reset(self):
+    def reset(self) -> Observation:
         """Reset episode and return initial observation."""
         self.cur_state = self.initial_state()
         assert self.cur_state in self.state_space, f"unexpected state {self.cur_state}"
         self._n_actions_taken = 0
         return self.obs_from_state(self.cur_state)
 
-    def step(self, action):
+    def step(self, action: Action) -> Tuple[Observation, float, bool, dict]:
         """Transition state using given action."""
         if self.cur_state is None or self._n_actions_taken is None:
             raise ValueError("Need to call reset() before first step()")
@@ -120,7 +130,7 @@ class ResettableEnv(gym.Env, abc.ABC):
         return obs, rew, done, infos
 
 
-class TabularModelEnv(ResettableEnv):
+class TabularModelEnv(ResettableEnv[int, int, int]):
     """Base class for tabular environments with known dynamics."""
 
     def __init__(

--- a/src/seals/base_envs.py
+++ b/src/seals/base_envs.py
@@ -63,7 +63,7 @@ class ResettablePOMDP(gym.Env, abc.ABC, Generic[State, Observation, Action]):
         """Is the state terminal?"""
 
     def obs_from_state(self, state: State) -> Observation:
-        """Returns observation produced by a given state."""
+        """Sample observation for given state."""
 
     @property
     def state_space(self) -> gym.Space:

--- a/src/seals/base_envs.py
+++ b/src/seals/base_envs.py
@@ -27,7 +27,7 @@ class ResettablePOMDP(gym.Env, abc.ABC, Generic[State, Observation, Action]):
         self,
         *,
         state_space: gym.Space,
-        observation_space: Optional[gym.Space] = None,
+        observation_space: gym.Space = None,
         action_space: gym.Space,
     ):
         """Build resettable (PO)MDP.
@@ -39,8 +39,6 @@ class ResettablePOMDP(gym.Env, abc.ABC, Generic[State, Observation, Action]):
             action_space: gym.Space containing possible actions.
         """
         self._state_space = state_space
-        if observation_space is None:
-            observation_space = state_space
         self._observation_space = observation_space
         self._action_space = action_space
 

--- a/src/seals/diagnostics/risky_path.py
+++ b/src/seals/diagnostics/risky_path.py
@@ -5,7 +5,7 @@ import numpy as np
 from seals import base_envs
 
 
-class RiskyPathEnv(base_envs.TabularModelEnv):
+class RiskyPathEnv(base_envs.TabularModelPOMDP):
     """Environment with two paths to a goal: one safe and one risky.
 
     Many LfH algorithms are derived from Maximum Entropy Inverse Reinforcement

--- a/src/seals/testing/envs.py
+++ b/src/seals/testing/envs.py
@@ -5,12 +5,23 @@ projects such as `imitation`, and may be useful in other codebases.
 """
 
 import re
-from typing import Any, Callable, Iterable, Iterator, Mapping, Optional, Sequence, Tuple
+from typing import (
+    Any,
+    Callable,
+    Iterable,
+    Iterator,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+)
 
 import gym
 import numpy as np
 
-Rollout = Sequence[Tuple[Any, Optional[float], bool, Mapping[str, Any]]]
+Step = Tuple[Any, Optional[float], bool, Mapping[str, Any]]
+Rollout = Sequence[Step]
 """A sequence of 4-tuples (obs, rew, done, info) as returned by `get_rollout`."""
 
 
@@ -70,7 +81,7 @@ def get_rollout(env: gym.Env, actions: Iterable[Any]) -> Rollout:
     Returns:
       A sequence of 4-tuples (obs, rew, done, info).
     """
-    ret = [(env.reset(), None, False, {})]
+    ret: List[Step] = [(env.reset(), None, False, {})]
     for act in actions:
         ret.append(env.step(act))
     return ret

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -40,7 +40,7 @@ class TestEnvs:
 def test_base_envs():
     """Test parts of base_envs not covered elsewhere."""
 
-    class NewEnv(base_envs.TabularModelEnv):
+    class NewEnv(base_envs.TabularModelPOMDP):
         def __init__(self):
             nS = 3
             nA = 2
@@ -68,27 +68,27 @@ def test_base_envs():
 def test_tabular_env_validation():
     """Test input validation for base_envs.TabularModelEnv."""
     with pytest.raises(ValueError, match=r"Malformed transition_matrix.*"):
-        base_envs.TabularModelEnv(
+        base_envs.TabularModelPOMDP(
             transition_matrix=np.zeros((3, 1, 4)), reward_matrix=np.zeros((3,)),
         )
     with pytest.raises(ValueError, match=r"initial_state_dist has multiple.*"):
-        base_envs.TabularModelEnv(
+        base_envs.TabularModelPOMDP(
             transition_matrix=np.zeros((3, 1, 3)),
             reward_matrix=np.zeros((3,)),
             initial_state_dist=np.zeros((3, 4)),
         )
     with pytest.raises(ValueError, match=r"transition_matrix and initial_state_dist.*"):
-        base_envs.TabularModelEnv(
+        base_envs.TabularModelPOMDP(
             transition_matrix=np.zeros((3, 1, 3)),
             reward_matrix=np.zeros((3,)),
             initial_state_dist=np.zeros((2)),
         )
     with pytest.raises(ValueError, match=r"transition_matrix and reward_matrix.*"):
-        base_envs.TabularModelEnv(
+        base_envs.TabularModelPOMDP(
             transition_matrix=np.zeros((4, 1, 4)), reward_matrix=np.zeros((3,)),
         )
 
-    env = base_envs.TabularModelEnv(
+    env = base_envs.TabularModelPOMDP(
         transition_matrix=np.zeros((3, 1, 3)), reward_matrix=np.zeros((3,)),
     )
     env.reset()

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -1,5 +1,7 @@
 """Smoke tests for all environments."""
 
+from typing import List
+
 import gym
 import numpy as np
 import pytest
@@ -8,13 +10,13 @@ import seals  # noqa: F401 required for env registration
 from seals import base_envs
 from seals.testing import envs
 
-ENV_NAMES = [
+ENV_NAMES: List[str] = [
     env_spec.id
     for env_spec in gym.envs.registration.registry.all()
     if env_spec.id.startswith(f"{seals.GYM_ID_PREFIX}/")
 ]
 
-DETERMINISTIC_ENVS = []
+DETERMINISTIC_ENVS: List[str] = []
 
 
 env = pytest.fixture(envs.make_env_fixture(skip_fn=pytest.skip))


### PR DESCRIPTION
This PR:
  - Splits `ResettableEnv` into `ResettablePOMDP` (base class) and `ResettableMDP` subclass. `TabularModelEnv` subclasses `ResettableMDP`.
  - Makes `ResettablePOMDP` and `ResettableMDP` generic classes, taking a `State`, `Observation` and `Action` type parameter.
  - Enables `mypy` *in addition* to `pytype`. `mypy` catches methods being overridden in a subclass with invalid types, whereas `pytype` does not. In general they seem to each have their blindspots, so running both is probably worth it.
  - Add a few extra type annotations, ignores, etc to make `mypy` happy.