### PR TITLE
Rename TabularModelPOMDP to TabularModelMDP and make observation_space mandatory

### DIFF
--- a/src/seals/base_envs.py
+++ b/src/seals/base_envs.py
@@ -125,7 +125,9 @@ class FullyObservableMixin(Generic[State]):
         return self.state_space
 
     def obs_from_state(self, state: State) -> State:
-        """Returns observation/state."""
+        """Returns the state as observation.
+        
+        In a fully observable MDP, the observations are the state."""
         return state
 
 

--- a/src/seals/base_envs.py
+++ b/src/seals/base_envs.py
@@ -126,8 +126,9 @@ class FullyObservableMixin(Generic[State]):
 
     def obs_from_state(self, state: State) -> State:
         """Returns the state as observation.
-        
-        In a fully observable MDP, the observations are the state."""
+
+        In a fully observable MDP, the observations are the state.
+        """
         return state
 
 

--- a/src/seals/base_envs.py
+++ b/src/seals/base_envs.py
@@ -51,9 +51,9 @@ class ResettablePOMDP(gym.Env, abc.ABC, Generic[State, Observation, Action]):
     def reward(self, state: State, action: Action, new_state: State) -> float:
         """Computes reward for a given transition."""
 
+    @abc.abstractmethod
     def terminal(self, state: State, step: int) -> bool:
         """Is the state terminal?"""
-        return False
 
     @abc.abstractmethod
     def obs_from_state(self, state: State) -> Observation:

--- a/src/seals/diagnostics/branching.py
+++ b/src/seals/diagnostics/branching.py
@@ -7,7 +7,7 @@ import numpy as np
 from seals import base_envs
 
 
-class BranchingEnv(base_envs.TabularModelPOMDP):
+class BranchingEnv(base_envs.TabularModelMDP):
     """Long branching environment requiring exploration.
 
     The agent must traverse a specific path of length L to reach a

--- a/src/seals/diagnostics/early_term.py
+++ b/src/seals/diagnostics/early_term.py
@@ -7,7 +7,7 @@ import numpy as np
 from seals import base_envs
 
 
-class EarlyTerminationEnv(base_envs.TabularModelPOMDP):
+class EarlyTerminationEnv(base_envs.TabularModelMDP):
     """Three-state MDP with early termination state.
 
     Many implementations of imitation learning algorithms incorrectly assign a

--- a/src/seals/diagnostics/init_shift.py
+++ b/src/seals/diagnostics/init_shift.py
@@ -8,7 +8,7 @@ import numpy as np
 from seals import base_envs
 
 
-class InitShiftEnv(base_envs.TabularModelPOMDP):
+class InitShiftEnv(base_envs.TabularModelMDP):
     """Tests for robustness to initial state shift.
 
     Many LfH algorithms learn from expert demonstrations. This can be

--- a/src/seals/diagnostics/risky_path.py
+++ b/src/seals/diagnostics/risky_path.py
@@ -5,7 +5,7 @@ import numpy as np
 from seals import base_envs
 
 
-class RiskyPathEnv(base_envs.TabularModelPOMDP):
+class RiskyPathEnv(base_envs.TabularModelMDP):
     """Environment with two paths to a goal: one safe and one risky.
 
     Many LfH algorithms are derived from Maximum Entropy Inverse Reinforcement

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -42,7 +42,7 @@ class TestEnvs:
 def test_base_envs():
     """Test parts of base_envs not covered elsewhere."""
 
-    class NewEnv(base_envs.TabularModelPOMDP):
+    class NewEnv(base_envs.TabularModelMDP):
         def __init__(self):
             nS = 3
             nA = 2
@@ -70,27 +70,27 @@ def test_base_envs():
 def test_tabular_env_validation():
     """Test input validation for base_envs.TabularModelEnv."""
     with pytest.raises(ValueError, match=r"Malformed transition_matrix.*"):
-        base_envs.TabularModelPOMDP(
+        base_envs.TabularModelMDP(
             transition_matrix=np.zeros((3, 1, 4)), reward_matrix=np.zeros((3,)),
         )
     with pytest.raises(ValueError, match=r"initial_state_dist has multiple.*"):
-        base_envs.TabularModelPOMDP(
+        base_envs.TabularModelMDP(
             transition_matrix=np.zeros((3, 1, 3)),
             reward_matrix=np.zeros((3,)),
             initial_state_dist=np.zeros((3, 4)),
         )
     with pytest.raises(ValueError, match=r"transition_matrix and initial_state_dist.*"):
-        base_envs.TabularModelPOMDP(
+        base_envs.TabularModelMDP(
             transition_matrix=np.zeros((3, 1, 3)),
             reward_matrix=np.zeros((3,)),
             initial_state_dist=np.zeros((2)),
         )
     with pytest.raises(ValueError, match=r"transition_matrix and reward_matrix.*"):
-        base_envs.TabularModelPOMDP(
+        base_envs.TabularModelMDP(
             transition_matrix=np.zeros((4, 1, 4)), reward_matrix=np.zeros((3,)),
         )
 
-    env = base_envs.TabularModelPOMDP(
+    env = base_envs.TabularModelMDP(
         transition_matrix=np.zeros((3, 1, 3)), reward_matrix=np.zeros((3,)),
     )
     env.reset()


### PR DESCRIPTION
A few things that looked off IMO on #21 :
- `ResettablePOMDP` said `observation_space` defaults to `state_space`, but it actually defaulted to `None`;
- `TabularModelPOMDP` was inheriting from `ResettableMDP` (shouldn't it be `TabularModelMDP` then?)

More generally, the observation model is composed of `observation_space` + `obs_from_state`, so I don't see the point of defining them separately (i.e. defining a `self._observation_space` in `ResettablePOMDP`).

It is also the case that "Tabular Model vs non-Tabular" and "partially observable vs. fully observable" are two independent axes, so it seems that they should be allowed to vary independently.

So I propose the following changes:
- Make `observation_space` and `obs_from_state` abstract in `ResettableEnv`
- Make `TabularModelPOMDP` an abstract class (missing `observation_space` + `obs_from_state`)
- Add a `FullyObservableMixin`, that makes a POMDP an MDP
- Make `TabularModelMDP = TabularModelPOMDP + FullyObservableMixin`
