### PR TITLE
Add documentation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 executors:
   my-executor:
     docker:
-      - image: humancompatibleai/benchmark-environments:base
+      - image: humancompatibleai/seals:base
     working_directory: /benchmark-environments
     environment:
       # If you change these, also change ci/code_checks.sh

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![CircleCI](https://circleci.com/gh/HumanCompatibleAI/seals.svg?style=svg)](https://circleci.com/gh/HumanCompatibleAI/seals)
-[![Documentation Status](https://readthedocs.org/projects/chai-seals/badge/?version=latest)](https://chai-seals.readthedocs.io/en/latest/?badge=latest)
+[![Documentation Status](https://readthedocs.org/projects/seals/badge/?version=latest)](https://seals.readthedocs.io/en/latest/?badge=latest)
 [![codecov](https://codecov.io/gh/HumanCompatibleAI/seals/branch/master/graph/badge.svg)](https://codecov.io/gh/HumanCompatibleAI/seals)
 [![PyPI version](https://badge.fury.io/py/seals.svg)](https://badge.fury.io/py/seals)
 

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
 
 **Status**: alpha, pre-release.
 
-The [CHAI](https://humancompatible.ai/) Suite of Environments for Algorithms that Learn 
-Specifications (SEALS) is a toolkit for evaluating specification learning algorithms, such as
-reward or imitation learning. The environments are compatible with [Gym](https://github.com/openai/gym),
-but are designed to test algorithms that learn from user data, without requiring a procedurally
-specified reward function.
+*seals*, the Suite of Environments for Algorithms that Learn Specifications, is a toolkit for
+evaluating specification learning algorithms, such as reward or imitation learning. The
+environments are compatible with [Gym](https://github.com/openai/gym), but are designed
+to test algorithms that learn from user data, without requiring a procedurally specified
+reward function.
 
 This is currently a work-in progress. While you are welcome to use the repository, we may make
 breaking changes at any time without prior notice. We intend for it to eventually contain:
@@ -22,6 +22,8 @@ breaking changes at any time without prior notice. We intend for it to eventuall
 You may also be interested in our sister project [imitation](https://github.com/humancompatibleai/imitation/),
 providing implementations of a variety of imitation and reward learning algorithms.
 
+Check out our [documentation](https://seals.readthedocs.io/en/latest/) for more information about *seals*.
+
 # Quickstart
 
 To install the latest release from PyPI, run:
@@ -30,7 +32,7 @@ To install the latest release from PyPI, run:
 pip install seals
 ```
 
-All SEALS environments are available in the Gym registry. Simply import it and then use as you
+All *seals* environments are available in the Gym registry. Simply import it and then use as you
 would with your usual RL or specification learning algroithm:
 
 ```python

--- a/docs/common/base_envs.rst
+++ b/docs/common/base_envs.rst
@@ -1,0 +1,7 @@
+.. _base_envs:
+
+Base Environments
+=================
+
+.. automodule:: seals.base_envs
+   :members:

--- a/docs/common/testing.rst
+++ b/docs/common/testing.rst
@@ -1,7 +1,7 @@
 .. _testing:
 
-Testing Helpers
-===============
+Helpers for unit-testing environments
+=====================================
 
 .. automodule:: seals.testing.envs
    :members:

--- a/docs/common/testing.rst
+++ b/docs/common/testing.rst
@@ -1,0 +1,7 @@
+.. _testing:
+
+Testing Helpers
+===============
+
+.. automodule:: seals.testing.envs
+   :members:

--- a/docs/common/util.rst
+++ b/docs/common/util.rst
@@ -1,0 +1,7 @@
+.. _util:
+
+Utilities
+=========
+
+.. automodule:: seals.util
+   :members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,7 +10,8 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
+import os
+
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
@@ -38,7 +39,9 @@ extensions = [
     "sphinx.ext.autosummary",
     "sphinx.ext.mathjax",
     "sphinx.ext.viewcode",
+    "sphinx_rtd_theme",
 ]
+autodoc_mock_imports = ["mujoco_py"]
 
 napoleon_google_docstring = True
 napoleon_numpy_docstring = False
@@ -57,7 +60,7 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = "alabaster"
+html_theme = "sphinx_rtd_theme"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/docs/environments/diagnostic.rst
+++ b/docs/environments/diagnostic.rst
@@ -1,0 +1,80 @@
+.. _diagnostic:
+
+Diagnostic Tasks
+================
+
+Diagnostic tasks test individual facets of algorithm performance in isolation.
+See the `DERAIL <https://arxiv.org/abs/2006.XXXXX>`_ paper for background information
+and benchmark results.
+
+Branching
+---------
+
+**Gym ID**: ``seals/Branching-v0``
+
+.. automodule:: seals.diagnostics.branching
+   :members:
+
+EarlyTerm
+---------
+
+**Gym ID**: ``seals/EarlyTermPos-v0`` and ``seals/EarlyTermNeg-v0``
+
+.. automodule:: seals.diagnostics.early_term
+   :members:
+
+InitShift
+---------
+
+**Gym ID**: ``seals/InitShiftTrain-v0`` and ``seals/InitShiftTest-v0seals/EarlyTermPos-v0``
+
+.. automodule:: seals.diagnostics.init_shift
+   :members:
+
+LargestSum
+-------------------
+
+**Gym ID**: ``seals/LargestSum-v0``
+
+.. automodule:: seals.diagnostics.largest_sum
+   :members:
+
+NoisyObs
+--------
+
+**Gym ID**: ``seals/NoisyObs-v0``
+
+.. automodule:: seals.diagnostics.noisy_obs
+   :members:
+
+Parabola
+--------
+
+**Gym ID**: ``seals/Parabola-v0``
+
+.. automodule:: seals.diagnostics.parabola
+   :members:
+
+ProcGoal
+--------
+
+**Gym ID**: ``seals/ProcGoal-v0``
+
+.. automodule:: seals.diagnostics.proc_goal
+   :members:
+
+RiskyPath
+---------
+
+**Gym ID**: ``seals/RiskyPath-v0``
+
+.. automodule:: seals.diagnostics.risky_path
+   :members:
+
+Sort
+----
+
+**Gym ID**: ``seals/Sort-v0``
+
+.. automodule:: seals.diagnostics.sort
+   :members:

--- a/docs/environments/diagnostic.rst
+++ b/docs/environments/diagnostic.rst
@@ -4,8 +4,6 @@ Diagnostic Tasks
 ================
 
 Diagnostic tasks test individual facets of algorithm performance in isolation.
-See the `DERAIL <https://arxiv.org/abs/2006.XXXXX>`_ paper for background information
-and benchmark results.
 
 Branching
 ---------

--- a/docs/environments/renovated.rst
+++ b/docs/environments/renovated.rst
@@ -3,6 +3,35 @@
 Renovated Environments
 ======================
 
+These environments are adaptations of widely-used reinforcement learning benchmarks from
+`Gym <https://github.com/openai/gym>`_, modified to be suitable for benchmarking specification
+learning algorithms. In particular, we:
+
+    * Make episodes fixed length. Since episode termination conditions are often correlated with
+      reward, variable-length episodes provide a side-channel of reward information that algorithms
+      can exploit. Critically, episode boundaries do not exist outside of simulation: in the
+      real-world, a human must often `"reset" the RL algorithm <https://www.youtube.com/watch?time_continue=125&v=vw3mGAlsT2U>`_.
+
+      Moreover, many algorithms do not properly handle episode termination, and so are
+      `biased <https://arxiv.org/abs/1809.02925>`_ towards shorter or longer episode boundaries.
+      This confounds evaluation, making some algorithms appear spuriously good or bad depending
+      on if their bias aligns with the task objective.
+
+      For most tasks, we make the episode fixed length simply by removing the early termination
+      condition. In some environments, such as *MountainCar*, it does not make sense to continue
+      after the terminal state: in this case, we make the terminal state an absorbing state that
+      is repeated until the end of the episode.
+    * Ensure observations include all information necessary to compute the ground-truth reward
+      function. For some environments, this has required augmenting the observation space.
+      We make this modification to make RL and specification learning of comparable difficulty
+      in these environments. While in general both RL and specification learning may need to
+      operate in partially observable environments, the observations in these relatively simple
+      environments were typically engineered to *make RL easy*: for a fair comparison, we must
+      therefore also provide reward learning algorithms with sufficient features to recover the
+      reward.
+
+In the future, we intend to add Atari tasks with the score masked, another reward side-channel.
+
 Classic Control
 ---------------
 

--- a/docs/environments/renovated.rst
+++ b/docs/environments/renovated.rst
@@ -1,0 +1,73 @@
+.. _renovated:
+
+Renovated Environments
+======================
+
+Classic Control
+---------------
+
+CartPole
+********
+
+**Gym ID**: ``seals/CartPole-v0``
+
+.. autoclass:: seals.classic_control.FixedHorizonCartPole
+   :members:
+
+MountainCar
+***********
+
+**Gym ID**: ``seals/MountainCar-v0``
+
+.. autofunction:: seals.classic_control.mountain_car
+
+MuJoCo
+------
+
+Ant
+***
+
+**Gym ID**: ``seals/Ant-v0``
+
+.. autoclass:: seals.mujoco.AntEnv
+   :members:
+
+HalfCheetah
+***********
+
+**Gym ID**: ``seals/HalfCheetah-v0``
+
+.. autoclass:: seals.mujoco.HalfCheetahEnv
+   :members:
+
+Hopper
+******
+
+**Gym ID**: ``seals/Hopper-v0``
+
+.. autoclass:: seals.mujoco.HopperEnv
+   :members:
+
+Humanoid
+********
+
+**Gym ID**: ``seals/Humanoid-v0``
+
+.. autoclass:: seals.mujoco.HumanoidEnv
+   :members:
+
+Swimmer
+*******
+
+**Gym ID**: ``seals/Swimmer-v0``
+
+.. autoclass:: seals.mujoco.SwimmerEnv
+   :members:
+
+Walker2d
+********
+
+**Gym ID**: ``seals/Walker2d-v0``
+
+.. autoclass:: seals.mujoco.Walker2dEnv
+   :members:

--- a/docs/guide/install.rst
+++ b/docs/guide/install.rst
@@ -1,0 +1,28 @@
+.. _install:
+
+Installation Instructions
+=========================
+
+To install the latest release from PyPi, run::
+
+    pip install seals
+
+We make releases periodically, but if you wish to use the latest version of the code, you can
+always install directly from Git master::
+
+    pip install git+https://github.com/HumanCompatibleAI/seals.git
+
+*seals* has optional dependencies needed by some subset of environments. In particular,
+to use MuJoCo environments, you will need to install `MuJoCo <http://www.mujoco.org/>`_ 1.5
+and then run::
+
+    pip install seals[mujoco]
+
+You may need to install some other binary dependencies: see the instructions in
+`Gym <https://github.com/openai/gym>`_ and `mujoco-py <https://github.com/openai/mujoco-py>`_
+for further information.
+
+You can also use our Docker image which includes all necessary binary dependencies. You can either
+build it from the ``Dockerfile``, or by downloading a pre-built image::
+
+    docker pull humancompatibleai/seals:base

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,8 +9,6 @@ that learn from user data, without requiring a procedurally specified reward fun
 There are two types of environments in *seals*:
 
     * **Diagnostic Tasks** which test individual facets of algorithm performance in isolation.
-      The `DERAIL <https://arxiv.org/abs/2006.XXXXX>`_ paper describes these tasks in detail
-      including benchmark results.
     * **Renovated Environments**, adaptations of widely-used benchmarks such as MuJoCo continuous
       control tasks to be suitable for specification learning benchmarks. In particular, this
       involves removing any side-channel sources of reward information (such as episode boundaries,
@@ -54,18 +52,6 @@ To cite this project in publications:
       publisher = {GitHub},
       journal = {GitHub repository},
       howpublished = {\url{https://github.com/HumanCompatibleAI/seals}},
-   }
-
-Additionally, if you use the diagnostic tasks, you may wish to cite:
-
-.. code-block:: bibtex
-
-    @inproceedings{freire:2020,
-      author = {Pedro Freire and Adam Gleave and Sam Toyer and Stuart Russell},
-      title = {{DERAIL}: Diagnostic Environments for Reward and Imitation Learning},
-      year = {2020},
-      booktitle = {Participatory ML Workshop at ICML},
-      url = {https://arxiv.org/abs/2006.XXXX},
    }
 
 Indices and tables

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,16 +1,65 @@
-.. seals documentation master file, created by
-   sphinx-quickstart on Mon Jan 13 20:48:50 2020.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
+SEALS User Guide
+================
 
-Welcome to seals's documentation!
-==================================================
+The Suite of Environments for Algorithms that Learn Specifications (SEALS) is a toolkit for
+evaluating specification learning algorithms, such as reward or imitation learning. The environments
+are compatible with `Gym <https://github.com/openai/gym/>`_, but are designed to test algorithms
+that learn from user data, without requiring a procedurally specified reward function.
+
+SEALS currently contains two types of environments:
+
+    * **Diagnostic Tasks** which test individual facets of algorithm performance in isolation.
+      The `DERAIL <https://arxiv.org/abs/2006.XXXXX>`_ paper describes these tasks in detail
+      including benchmark results.
+    * **Renovated Environments**, adaptations of widely-used benchmarks such as MuJoCo continuous
+      control tasks to be suitable for specification learning benchmarks. In particular, this
+      involves removing any side-channel sources of reward information (such as episode boundaries,
+      the score appearing in the observation, etc) and including all the information needed to
+      compute the reward in the observation space.
+
+SEALS is under active development and we intend to add more categories of tasks soon.
 
 .. toctree::
-   :maxdepth: 2
-   :caption: Contents:
+   :maxdepth: 1
+   :caption: Environments
 
+   environments/diagnostic
+   environments/renovated
 
+.. toctree::
+   :maxdepth: 1
+   :caption: Common
+
+   common/base_envs
+   common/util
+   common/testing
+
+Citing SEALS
+------------
+To cite this project in publications:
+
+.. code-block:: bibtex
+
+    @misc{seals,
+      author = {Adam Gleave and Pedro Freire and Steven Wang and Sam Toyer},
+      title = {SEALS: Suite of Environments for Algorithms that Learn Specifications},
+      year = {2020},
+      publisher = {GitHub},
+      journal = {GitHub repository},
+      howpublished = {\url{https://github.com/HumanCompatibleAI/seals}},
+   }
+
+Additionally, if you use the diagnostic tasks, you may wish to cite:
+
+.. code-block:: bibtex
+
+    @inproceedings{freire:2020,
+      author = {Pedro Freire and Adam Gleave and Sam Toyer and Stuart Russell},
+      title = {DERAIL: Diagnostic Environments for Reward and Imitation Learning},
+      year = {2020},
+      booktitle = {Participatory ML Workshop at ICML},
+      url = {https://arxiv.org/abs/2006.XXXX},
+   }
 
 Indices and tables
 ==================

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,12 +1,12 @@
-SEALS User Guide
+seals User Guide
 ================
 
-The Suite of Environments for Algorithms that Learn Specifications (SEALS) is a toolkit for
+The Suite of Environments for Algorithms that Learn Specifications, or *seals*, is a toolkit for
 evaluating specification learning algorithms, such as reward or imitation learning. The environments
 are compatible with `Gym <https://github.com/openai/gym/>`_, but are designed to test algorithms
 that learn from user data, without requiring a procedurally specified reward function.
 
-SEALS currently contains two types of environments:
+There are two types of environments in *seals*:
 
     * **Diagnostic Tasks** which test individual facets of algorithm performance in isolation.
       The `DERAIL <https://arxiv.org/abs/2006.XXXXX>`_ paper describes these tasks in detail
@@ -17,24 +17,31 @@ SEALS currently contains two types of environments:
       the score appearing in the observation, etc) and including all the information needed to
       compute the reward in the observation space.
 
-SEALS is under active development and we intend to add more categories of tasks soon.
+*seals* is under active development and we intend to add more categories of tasks soon.
 
 .. toctree::
    :maxdepth: 1
+   :caption: User Guide
+
+   guide/install
+
+
+.. toctree::
+   :maxdepth: 3
    :caption: Environments
 
    environments/diagnostic
    environments/renovated
 
 .. toctree::
-   :maxdepth: 1
+   :maxdepth: 2
    :caption: Common
 
    common/base_envs
    common/util
    common/testing
 
-Citing SEALS
+Citing seals
 ------------
 To cite this project in publications:
 
@@ -42,7 +49,7 @@ To cite this project in publications:
 
     @misc{seals,
       author = {Adam Gleave and Pedro Freire and Steven Wang and Sam Toyer},
-      title = {SEALS: Suite of Environments for Algorithms that Learn Specifications},
+      title = {{seals}: Suite of Environments for Algorithms that Learn Specifications},
       year = {2020},
       publisher = {GitHub},
       journal = {GitHub repository},
@@ -55,7 +62,7 @@ Additionally, if you use the diagnostic tasks, you may wish to cite:
 
     @inproceedings{freire:2020,
       author = {Pedro Freire and Adam Gleave and Sam Toyer and Stuart Russell},
-      title = {DERAIL: Diagnostic Environments for Reward and Imitation Learning},
+      title = {{DERAIL}: Diagnostic Environments for Reward and Imitation Learning},
       year = {2020},
       booktitle = {Participatory ML Workshop at ICML},
       url = {https://arxiv.org/abs/2006.XXXX},

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ TESTS_REQUIRE = [
 ]
 DOCS_REQUIRE = [
     "sphinx",
+    "sphinx-rtd-theme",
     "sphinxcontrib-napoleon",
 ]
 

--- a/src/seals/classic_control.py
+++ b/src/seals/classic_control.py
@@ -1,4 +1,4 @@
-"""Adaptation of classic Gym environments for IRL."""
+"""Adaptation of classic Gym environments for specification learning algorithms."""
 
 import warnings
 

--- a/src/seals/diagnostics/risky_path.py
+++ b/src/seals/diagnostics/risky_path.py
@@ -11,7 +11,7 @@ class RiskyPathEnv(base_envs.TabularModelMDP):
     Many LfH algorithms are derived from Maximum Entropy Inverse Reinforcement
     Learning [1], which models the demonstrator as producing trajectories with
     probability p(tau) proportional to exp(R(tau)).  This model implies that a
-    demonstrator can ``control'' the environment well enough to follow any
+    demonstrator can "control" the environment well enough to follow any
     high-reward trajectory with high probability [2]. However, in stochastic
     environments, the agent cannot control the probability of each trajectory
     independently.  This misspecification may lead to poor behavior.

--- a/src/seals/mujoco.py
+++ b/src/seals/mujoco.py
@@ -1,4 +1,4 @@
-"""Adaptation of MuJoCo environments for IRL."""
+"""Adaptation of MuJoCo environments for specification learning algorithms."""
 
 import functools
 

--- a/src/seals/testing/envs.py
+++ b/src/seals/testing/envs.py
@@ -30,16 +30,20 @@ def make_env_fixture(
 ) -> Callable[[str], Iterator[gym.Env]]:
     """Creates a fixture function, calling `skip_fn` when dependencies are missing.
 
-    For example, in `pytest`, one would use:
+    For example, in `pytest`, one would use::
+
         env = pytest.fixture(make_env_fixture(skip_fn=pytest.skip))
+
     Then any method with an `env` parameter will receive the created environment, with
     the `env_name` parameter automatically passed to the fixture.
 
-    In `unittest`, one would use:
+    In `unittest`, one would use::
+
         def skip_fn(msg):
             raise unittest.SkipTest(msg)
 
         make_env = contextlib.contextmanager(make_env_fixture(skip_fn=skip_fn))
+
     And then call `with make_env(env_name) as env:` to create environments.
 
     Args:


### PR DESCRIPTION
Adds basic intro to the documentation, and uses autodoc to include docstrings for the other modules.

Need to wait until arXiv submission and Participatory ML notification before merging so we can update paper links & BibTeX appropriately.

Should maybe also include an installation guide and contribution section? Or just link to `README` which already includes these?

In general not happy with how WET (Write Everything Twice) this has ended up being, e.g. the Gym IDs are now in the docs + in `__init__.py`, but I can't see a DRY way of doing this that is user-friendly.