### PR TITLE
Completely remove mujoco_py dependencies from envs.testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ commands:
           # Build a wheel then install to avoid copying whole directory (pip issue #2195)
           command: |
             python setup.py sdist bdist_wheel
-            pip install --upgrade dist/seals-*.whl
+            pip install --upgrade --force-reinstall --no-deps dist/seals-*.whl
 
 # The `jobs` section defines jobs that can be executed on CircleCI as part of workflows.
 jobs:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,8 @@
 [tool.black]
 target-version = ["py37"]
+
+[[tool.mypy.overrides]]
+module = [
+    "gym.*"
+]
+ignore_missing_imports = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,13 +40,6 @@ inputs =
 	setup.py
 python_version = 3.7
 
-[mypy-gym.*]
-ignore_missing_imports = True
-[mypy-numpy.*]
-ignore_missing_imports = True
-[mypy-pytest.*]
-ignore_missing_imports = True
-
 [tool:pytest]
 markers =
     expensive: mark a test as expensive (deselect with '-m "not expensive"')

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ TESTS_REQUIRE = [
     "pytest-xdist",
     "pytype",
     "stable-baselines3>=0.9.0",
+    "pyglet>=1.4.0",
 ]
 DOCS_REQUIRE = [
     "sphinx",
@@ -68,7 +69,7 @@ setup(
     packages=find_packages("src"),
     package_dir={"": "src"},
     package_data={"seals": ["py.typed"]},
-    install_requires=["gym", "pyglet"],
+    install_requires=["gym"],
     tests_require=TESTS_REQUIRE,
     extras_require={
         # recommended packages for development

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
     packages=find_packages("src"),
     package_dir={"": "src"},
     package_data={"seals": ["py.typed"]},
-    install_requires=["gym"],
+    install_requires=["gym", "pyglet"],
     tests_require=TESTS_REQUIRE,
     extras_require={
         # recommended packages for development

--- a/src/seals/diagnostics/sort.py
+++ b/src/seals/diagnostics/sort.py
@@ -51,7 +51,7 @@ class SortEnv(base_envs.ResettableMDP):
 
         return float(self._is_sorted(new_state)) + potential_diff
 
-    def transition(self, state: np.ndarray, action: np.ndarray) -> float:
+    def transition(self, state: np.ndarray, action: np.ndarray) -> np.ndarray:
         """Action a = (i, j) swaps elements in positions i and j."""
         new_state = state.copy()
         i, j = action

--- a/src/seals/testing/envs.py
+++ b/src/seals/testing/envs.py
@@ -18,12 +18,6 @@ from typing import (
 )
 
 import gym
-try:  # noqa: I003
-    from gym.envs.mujoco import mujoco_env
-    MUJOCO_AVAILABLE = True
-except gym.error.DependencyNotInstalled:
-    mujoco_env = None
-    MUJOCO_AVAILABLE = False
 import numpy as np
 
 Step = Tuple[Any, Optional[float], bool, Mapping[str, Any]]
@@ -235,7 +229,7 @@ def test_premature_step(env: gym.Env, skip_fn, raises_fn) -> None:
     Raises:
         AssertionError if test fails.
     """
-    if MUJOCO_AVAILABLE and isinstance(env.unwrapped, mujoco_env.MujocoEnv):
+    if _check_is_mujoco_env(env): # pragma: no cover
         # We can't use isinstance since importing mujoco_py will fail on
         # machines without MuJoCo installed
         skip_fn("MuJoCo environments cannot perform this check.")
@@ -279,13 +273,17 @@ def test_render(env: gym.Env, raises_fn) -> None:
         # on the viewer (commented out) so the resources are not released.
         # For now this is OK, but may bite if we end up testing a lot of
         # MuJoCo environments.
-        is_mujoco = MUJOCO_AVAILABLE and isinstance(env.unwrapped, mujoco_env.MujocoEnv)
+        is_mujoco = _check_is_mujoco_env(env) # pragma: no cover
         if "rgb_array" in render_modes and not is_mujoco:
             # Render should not change without calling `step()`.
             # MuJoCo rendering fails this check, ignore -- not much we can do.
             resa = env.render(mode="rgb_array")
             resb = env.render(mode="rgb_array")
             assert np.allclose(resa, resb)
+
+
+def _check_is_mujoco_env(env: gym.Env) -> bool:
+    return hasattr(env, "sim") and hasattr(env, "model")
 
 
 class CountingEnv(gym.Env):

--- a/src/seals/testing/envs.py
+++ b/src/seals/testing/envs.py
@@ -235,8 +235,7 @@ def test_premature_step(env: gym.Env, skip_fn, raises_fn) -> None:
     Raises:
         AssertionError if test fails.
     """
-    if MUJOCO_AVAILABLE and isinstance(env.unwrapped, mujoco_env.MujocoEnv): # pragma: no cover
-        # if hasattr(env, "sim") and hasattr(env, "model"):  
+    if MUJOCO_AVAILABLE and isinstance(env.unwrapped, mujoco_env.MujocoEnv):
         # We can't use isinstance since importing mujoco_py will fail on
         # machines without MuJoCo installed
         skip_fn("MuJoCo environments cannot perform this check.")

--- a/src/seals/testing/envs.py
+++ b/src/seals/testing/envs.py
@@ -18,12 +18,7 @@ from typing import (
 )
 
 import gym
-try:  # noqa: I003
-    from gym.envs.mujoco import mujoco_env
-    MUJOCO_AVAILABLE = True
-except gym.error.DependencyNotInstalled:
-    mujoco_env = None
-    MUJOCO_AVAILABLE = False
+from gym.envs.mujoco import mujoco_env
 import numpy as np
 
 Step = Tuple[Any, Optional[float], bool, Mapping[str, Any]]
@@ -235,7 +230,7 @@ def test_premature_step(env: gym.Env, skip_fn, raises_fn) -> None:
     Raises:
         AssertionError if test fails.
     """
-    if MUJOCO_AVAILABLE and isinstance(env.unwrapped, mujoco_env.MujocoEnv):
+    if hasattr(env, "sim") and hasattr(env, "model"):  # pragma: no cover
         # We can't use isinstance since importing mujoco_py will fail on
         # machines without MuJoCo installed
         skip_fn("MuJoCo environments cannot perform this check.")
@@ -279,7 +274,7 @@ def test_render(env: gym.Env, raises_fn) -> None:
         # on the viewer (commented out) so the resources are not released.
         # For now this is OK, but may bite if we end up testing a lot of
         # MuJoCo environments.
-        is_mujoco = MUJOCO_AVAILABLE and isinstance(env.unwrapped, mujoco_env.MujocoEnv)
+        is_mujoco = isinstance(env.unwrapped, mujoco_env.MujocoEnv)
         if "rgb_array" in render_modes and not is_mujoco:
             # Render should not change without calling `step()`.
             # MuJoCo rendering fails this check, ignore -- not much we can do.

--- a/src/seals/testing/envs.py
+++ b/src/seals/testing/envs.py
@@ -18,7 +18,12 @@ from typing import (
 )
 
 import gym
-from gym.envs.mujoco import mujoco_env
+try:  # noqa: I003
+    from gym.envs.mujoco import mujoco_env
+    MUJOCO_AVAILABLE = True
+except gym.error.DependencyNotInstalled:
+    mujoco_env = None
+    MUJOCO_AVAILABLE = False
 import numpy as np
 
 Step = Tuple[Any, Optional[float], bool, Mapping[str, Any]]
@@ -230,7 +235,7 @@ def test_premature_step(env: gym.Env, skip_fn, raises_fn) -> None:
     Raises:
         AssertionError if test fails.
     """
-    if hasattr(env, "sim") and hasattr(env, "model"):  # pragma: no cover
+    if MUJOCO_AVAILABLE and isinstance(env.unwrapped, mujoco_env.MujocoEnv):
         # We can't use isinstance since importing mujoco_py will fail on
         # machines without MuJoCo installed
         skip_fn("MuJoCo environments cannot perform this check.")
@@ -274,7 +279,7 @@ def test_render(env: gym.Env, raises_fn) -> None:
         # on the viewer (commented out) so the resources are not released.
         # For now this is OK, but may bite if we end up testing a lot of
         # MuJoCo environments.
-        is_mujoco = isinstance(env.unwrapped, mujoco_env.MujocoEnv)
+        is_mujoco = MUJOCO_AVAILABLE and isinstance(env.unwrapped, mujoco_env.MujocoEnv)
         if "rgb_array" in render_modes and not is_mujoco:
             # Render should not change without calling `step()`.
             # MuJoCo rendering fails this check, ignore -- not much we can do.

--- a/src/seals/testing/envs.py
+++ b/src/seals/testing/envs.py
@@ -183,6 +183,10 @@ def _sample_and_check(env: gym.Env, obs_space: gym.Space) -> bool:
     return done
 
 
+def _is_mujoco_env(env: gym.Env) -> bool:
+    return hasattr(env, "sim") and hasattr(env, "model")
+
+
 def test_rollout_schema(
     env: gym.Env,
     steps_after_done: int = 10,
@@ -229,7 +233,7 @@ def test_premature_step(env: gym.Env, skip_fn, raises_fn) -> None:
     Raises:
         AssertionError if test fails.
     """
-    if _check_is_mujoco_env(env):  # pragma: no cover
+    if _is_mujoco_env(env):  # pragma: no cover
         # We can't use isinstance since importing mujoco_py will fail on
         # machines without MuJoCo installed
         skip_fn("MuJoCo environments cannot perform this check.")
@@ -273,17 +277,13 @@ def test_render(env: gym.Env, raises_fn) -> None:
         # on the viewer (commented out) so the resources are not released.
         # For now this is OK, but may bite if we end up testing a lot of
         # MuJoCo environments.
-        is_mujoco = _check_is_mujoco_env(env)  # pragma: no cover
+        is_mujoco = _is_mujoco_env(env)  # pragma: no cover
         if "rgb_array" in render_modes and not is_mujoco:
             # Render should not change without calling `step()`.
             # MuJoCo rendering fails this check, ignore -- not much we can do.
             resa = env.render(mode="rgb_array")
             resb = env.render(mode="rgb_array")
             assert np.allclose(resa, resb)
-
-
-def _check_is_mujoco_env(env: gym.Env) -> bool:
-    return hasattr(env, "sim") and hasattr(env, "model")
 
 
 class CountingEnv(gym.Env):

--- a/src/seals/testing/envs.py
+++ b/src/seals/testing/envs.py
@@ -18,7 +18,6 @@ from typing import (
 )
 
 import gym
-from gym.envs.mujoco import mujoco_env
 import numpy as np
 
 Step = Tuple[Any, Optional[float], bool, Mapping[str, Any]]
@@ -274,7 +273,7 @@ def test_render(env: gym.Env, raises_fn) -> None:
         # on the viewer (commented out) so the resources are not released.
         # For now this is OK, but may bite if we end up testing a lot of
         # MuJoCo environments.
-        is_mujoco = isinstance(env.unwrapped, mujoco_env.MujocoEnv)
+        is_mujoco = if hasattr(env, "sim") and hasattr(env, "model")
         if "rgb_array" in render_modes and not is_mujoco:
             # Render should not change without calling `step()`.
             # MuJoCo rendering fails this check, ignore -- not much we can do.

--- a/src/seals/testing/envs.py
+++ b/src/seals/testing/envs.py
@@ -18,6 +18,12 @@ from typing import (
 )
 
 import gym
+try:  # noqa: I003
+    from gym.envs.mujoco import mujoco_env
+    MUJOCO_AVAILABLE = True
+except gym.error.DependencyNotInstalled:
+    mujoco_env = None
+    MUJOCO_AVAILABLE = False
 import numpy as np
 
 Step = Tuple[Any, Optional[float], bool, Mapping[str, Any]]
@@ -229,7 +235,8 @@ def test_premature_step(env: gym.Env, skip_fn, raises_fn) -> None:
     Raises:
         AssertionError if test fails.
     """
-    if hasattr(env, "sim") and hasattr(env, "model"):  # pragma: no cover
+    if MUJOCO_AVAILABLE and isinstance(env.unwrapped, mujoco_env.MujocoEnv): # pragma: no cover
+        # if hasattr(env, "sim") and hasattr(env, "model"):  
         # We can't use isinstance since importing mujoco_py will fail on
         # machines without MuJoCo installed
         skip_fn("MuJoCo environments cannot perform this check.")
@@ -273,7 +280,7 @@ def test_render(env: gym.Env, raises_fn) -> None:
         # on the viewer (commented out) so the resources are not released.
         # For now this is OK, but may bite if we end up testing a lot of
         # MuJoCo environments.
-        is_mujoco = hasattr(env, "sim") and hasattr(env, "model")
+        is_mujoco = MUJOCO_AVAILABLE and isinstance(env.unwrapped, mujoco_env.MujocoEnv)
         if "rgb_array" in render_modes and not is_mujoco:
             # Render should not change without calling `step()`.
             # MuJoCo rendering fails this check, ignore -- not much we can do.

--- a/src/seals/testing/envs.py
+++ b/src/seals/testing/envs.py
@@ -229,7 +229,7 @@ def test_premature_step(env: gym.Env, skip_fn, raises_fn) -> None:
     Raises:
         AssertionError if test fails.
     """
-    if _check_is_mujoco_env(env): # pragma: no cover
+    if _check_is_mujoco_env(env):  # pragma: no cover
         # We can't use isinstance since importing mujoco_py will fail on
         # machines without MuJoCo installed
         skip_fn("MuJoCo environments cannot perform this check.")
@@ -273,7 +273,7 @@ def test_render(env: gym.Env, raises_fn) -> None:
         # on the viewer (commented out) so the resources are not released.
         # For now this is OK, but may bite if we end up testing a lot of
         # MuJoCo environments.
-        is_mujoco = _check_is_mujoco_env(env) # pragma: no cover
+        is_mujoco = _check_is_mujoco_env(env)  # pragma: no cover
         if "rgb_array" in render_modes and not is_mujoco:
             # Render should not change without calling `step()`.
             # MuJoCo rendering fails this check, ignore -- not much we can do.

--- a/src/seals/testing/envs.py
+++ b/src/seals/testing/envs.py
@@ -277,7 +277,7 @@ def test_render(env: gym.Env, raises_fn) -> None:
         # on the viewer (commented out) so the resources are not released.
         # For now this is OK, but may bite if we end up testing a lot of
         # MuJoCo environments.
-        is_mujoco = _is_mujoco_env(env)  # pragma: no cover
+        is_mujoco = _is_mujoco_env(env)
         if "rgb_array" in render_modes and not is_mujoco:
             # Render should not change without calling `step()`.
             # MuJoCo rendering fails this check, ignore -- not much we can do.

--- a/src/seals/testing/envs.py
+++ b/src/seals/testing/envs.py
@@ -273,7 +273,7 @@ def test_render(env: gym.Env, raises_fn) -> None:
         # on the viewer (commented out) so the resources are not released.
         # For now this is OK, but may bite if we end up testing a lot of
         # MuJoCo environments.
-        is_mujoco = if hasattr(env, "sim") and hasattr(env, "model")
+        is_mujoco = hasattr(env, "sim") and hasattr(env, "model")
         if "rgb_array" in render_modes and not is_mujoco:
             # Render should not change without calling `step()`.
             # MuJoCo rendering fails this check, ignore -- not much we can do.

--- a/src/seals/util.py
+++ b/src/seals/util.py
@@ -137,11 +137,9 @@ def get_gym_max_episode_steps(env_name: str) -> Optional[int]:
 
 def sample_distribution(
     p: np.ndarray,
-    random: Optional[np.random.RandomState] = None,
+    random: np.random.RandomState,
 ) -> int:
     """Samples an integer with probabilities given by p."""
-    if random is None:
-        random = np.random
     return random.choice(np.arange(len(p)), p=p)
 
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -14,8 +14,9 @@ def test_sample_distribution():
     distr /= distr.sum()
 
     n_samples = 1000
+    rng = np.random.RandomState()
     sample_count = collections.Counter(
-        util.sample_distribution(distr) for _ in range(n_samples)
+        util.sample_distribution(distr, rng) for _ in range(n_samples)
     )
 
     empirical_distr = np.array([sample_count[i] for i in range(distr_size)]) / n_samples

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -86,7 +86,7 @@ def test_absorb_repeat_final_state(episode_length=6, n_steps=100, n_manual_reset
             assert rew == expected_rew
 
 
-@pytest.mark.parametrize("dtype", [np.int, np.float32, np.float64])
+@pytest.mark.parametrize("dtype", [np.int64, np.float32, np.float64])
 def test_obs_cast(dtype: np.dtype, episode_length: int = 5):
     """Check obs_cast observations are of specified dtype and not mangled.
 


### PR DESCRIPTION
Remove `import mujoco_py` and its use in L276. Replace `isinstance` with attribute tests on `sim` and `model`, this method is the same as L233.