### PR TITLE
Give parabola finite action space

### DIFF
--- a/src/seals/diagnostics/parabola.py
+++ b/src/seals/diagnostics/parabola.py
@@ -32,7 +32,7 @@ class ParabolaEnv(base_envs.ResettableMDP):
 
         super().__init__(
             state_space=spaces.Box(low=state_low, high=state_high),
-            action_space=spaces.Box(low=-2*bounds, high=2*bounds, shape=()),
+            action_space=spaces.Box(low=(-2) * bounds, high=2 * bounds, shape=()),
         )
 
     def terminal(self, state: int, n_actions_taken: int) -> bool:

--- a/src/seals/diagnostics/parabola.py
+++ b/src/seals/diagnostics/parabola.py
@@ -32,7 +32,7 @@ class ParabolaEnv(base_envs.ResettableMDP):
 
         super().__init__(
             state_space=spaces.Box(low=state_low, high=state_high),
-            action_space=spaces.Box(low=-np.inf, high=np.inf, shape=()),
+            action_space=spaces.Box(low=-2*bounds, high=2*bounds, shape=()),
         )
 
     def terminal(self, state: int, n_actions_taken: int) -> bool:


### PR DESCRIPTION
Currently, the action space in parabola is infinitely large, which breaks some RL algorithms (e.g. PPO). This change makes the space finite: the interval $[-2 \times bounds, 2 \times bounds]$. This is because actions are added to the y-coordinate, which is then clipped to be in the interval $[-bounds, bounds]$.

NB: I haven't actually gotten seals properly working on my laptop, so am hoping that tests get run automatically by some CI process.