### PR TITLE
Add score masking to seven atari environments

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -115,7 +115,10 @@ TESTS_REQUIRE = [
     "pytest-xdist",
     "pytype",
     "stable-baselines3>=0.9.0",
-    "pyglet>=1.4.0",
+    # TODO(adam): remove pyglet pin once Gym upgraded to >0.21
+    # Workaround for https://github.com/openai/gym/issues/2986
+    # Discussed in https://github.com/HumanCompatibleAI/imitation/pull/603
+    "pyglet==1.5.27",
     "setuptools_scm~=7.0.5",
     *ATARI_REQUIRE,
 ]

--- a/src/seals/atari.py
+++ b/src/seals/atari.py
@@ -38,7 +38,7 @@ def make_atari_env(atari_env_id: str, masked: bool) -> gym.Env:
         if score_region is None:
             raise ValueError(
                 "Requested environment does not yet support masking. "
-                + "See https://github.com/HumanCompatibleAI/seals/issues/61.",
+                "See https://github.com/HumanCompatibleAI/seals/issues/61.",
             )
         env = MaskScoreWrapper(env, score_region)
 
@@ -76,7 +76,7 @@ def _seals_name(gym_spec: gym.envs.registration.EnvSpec, masked: bool) -> str:
     name = "seals/" + slash_separated[-1]
 
     if not masked:
-        last_hyphen_idx = name.rfind("-")
+        last_hyphen_idx = name.rfind("-v")
         name = name[:last_hyphen_idx] + "-Unmasked" + name[last_hyphen_idx:]
     return name
 
@@ -85,17 +85,16 @@ def register_atari_envs(
     gym_atari_env_specs: Iterable[gym.envs.registration.EnvSpec],
 ) -> None:
     """Register masked and unmasked wrapped gym Atari environments."""
-    for gym_spec in gym_atari_env_specs:
+
+    def register_gym(masked):
         gym.register(
-            id=_seals_name(gym_spec, masked=False),
+            id=_seals_name(gym_spec, masked=masked),
             entry_point="seals.atari:make_atari_env",
             max_episode_steps=get_gym_max_episode_steps(gym_spec.id),
-            kwargs=dict(atari_env_id=gym_spec.id, masked=False),
+            kwargs=dict(atari_env_id=gym_spec.id, masked=masked),
         )
+
+    for gym_spec in gym_atari_env_specs:
+        register_gym(masked=False)
         if _get_score_region(gym_spec.id) is not None:
-            gym.register(
-                id=_seals_name(gym_spec, masked=True),
-                entry_point="seals.atari:make_atari_env",
-                max_episode_steps=get_gym_max_episode_steps(gym_spec.id),
-                kwargs=dict(atari_env_id=gym_spec.id, masked=True),
-            )
+            register_gym(masked=True)

--- a/src/seals/atari.py
+++ b/src/seals/atari.py
@@ -1,29 +1,35 @@
 """Adaptation of Atari environments for specification learning algorithms."""
 
-from typing import Dict, Iterable, List, Optional, Tuple
+from typing import Dict, Iterable, Optional
 
 import gym
 
-from seals.util import AutoResetWrapper, MaskScoreWrapper, get_gym_max_episode_steps
+from seals.util import (
+    AutoResetWrapper,
+    BoxRegion,
+    MaskedRegionSpecifier,
+    MaskScoreWrapper,
+    get_gym_max_episode_steps,
+)
 
-SCORE_REGIONS: Dict[str, List[Dict[str, Tuple[int, int]]]] = {
+SCORE_REGIONS: Dict[str, MaskedRegionSpecifier] = {
     "BeamRider": [
-        dict(x=(5, 20), y=(45, 120)),
-        dict(x=(28, 40), y=(15, 40)),
+        BoxRegion(x=(5, 20), y=(45, 120)),
+        BoxRegion(x=(28, 40), y=(15, 40)),
     ],
-    "Breakout": [dict(x=(0, 16), y=(35, 80))],
+    "Breakout": [BoxRegion(x=(0, 16), y=(35, 80))],
     "Enduro": [
-        dict(x=(163, 173), y=(55, 110)),
-        dict(x=(177, 188), y=(68, 107)),
+        BoxRegion(x=(163, 173), y=(55, 110)),
+        BoxRegion(x=(177, 188), y=(68, 107)),
     ],
-    "Pong": [dict(x=(0, 24), y=(0, 160))],
-    "Qbert": [dict(x=(6, 15), y=(33, 71))],
-    "Seaquest": [dict(x=(7, 19), y=(80, 110))],
-    "SpaceInvaders": [dict(x=(10, 20), y=(0, 160))],
+    "Pong": [BoxRegion(x=(0, 24), y=(0, 160))],
+    "Qbert": [BoxRegion(x=(6, 15), y=(33, 71))],
+    "Seaquest": [BoxRegion(x=(7, 19), y=(80, 110))],
+    "SpaceInvaders": [BoxRegion(x=(10, 20), y=(0, 160))],
 }
 
 
-def _get_score_region(atari_env_id: str) -> Optional[List[Dict[str, Tuple[int, int]]]]:
+def _get_score_region(atari_env_id: str) -> Optional[MaskedRegionSpecifier]:
     basename = atari_env_id.split("/")[-1].split("-")[0]
     basename = basename.replace("NoFrameskip", "")
     return SCORE_REGIONS.get(basename)

--- a/src/seals/util.py
+++ b/src/seals/util.py
@@ -46,13 +46,17 @@ class MaskScoreWrapper(gym.Wrapper):
                 and `y0 < y1`.
             fill_value: The fill_value for the masked region. By default is black.
                 Can support RGB colors by being a sequence of values [r, g, b].
+
+        Raises:
+            ValueError: If a score region does not conform to the spec.
         """
         super().__init__(env)
         self.fill_value = np.array(fill_value, env.observation_space.dtype)
 
         self.mask = np.ones(env.observation_space.shape, dtype=bool)
         for r in score_regions:
-            assert r["x"][0] < r["x"][1] and r["y"][0] < r["y"][1]
+            if r["x"][0] >= r["x"][1] or r["y"][0] >= r["y"][1]:
+                raise ValueError('Invalid region: "x" and "y" must be increasing.')
             self.mask[r["x"][0] : r["x"][1], r["y"][0] : r["y"][1]] = 0
 
     def _mask_obs(self, obs):

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -76,7 +76,7 @@ def test_atari_unmasked_env_naming():
         filter(
             lambda name: _get_score_region(name) is None and "Unmasked" not in name,
             ATARI_ENVS,
-        )
+        ),
     )
     assert len(noncompliant_envs) == 0
 

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -26,7 +26,11 @@ DETERMINISTIC_ENVS: List[str] = [
 ]
 
 ATARI_ENVS: List[str] = [
-    _seals_name(gym_spec) for gym_spec in seals.GYM_ATARI_ENV_SPECS
+    _seals_name(gym_spec, masked=False) for gym_spec in seals.GYM_ATARI_ENV_SPECS
+] + [
+    _seals_name(gym_spec, masked=True)
+    for gym_spec in seals.GYM_ATARI_ENV_SPECS
+    if _get_score_region(gym_spec.id) is not None
 ]
 
 ATARI_V5_ENVS: List[str] = list(filter(lambda name: name.endswith("-v5"), ATARI_ENVS))
@@ -46,25 +50,31 @@ def test_some_atari_envs():
 
 
 def test_atari_space_invaders():
-    """Tests if there's an Atari environment called space invaders."""
-    space_invader_environments = list(
+    """Tests for masked and unmasked Atari space invaders environments."""
+    masked_space_invader_environments = list(
         filter(
-            lambda name: "SpaceInvaders" in name,
+            lambda name: "SpaceInvaders" in name and "Unmasked" not in name,
             ATARI_ENVS,
         ),
     )
-    assert len(space_invader_environments) > 0
+    assert len(masked_space_invader_environments) > 0
 
-
-def test_no_atari_unmasked():
-    """Tests that we only load Atari envs with score masking implemented."""
-    non_masked_environments = list(
+    unmasked_space_invader_environments = list(
         filter(
-            lambda name: _get_score_region(name) is None,
+            lambda name: "SpaceInvaders" in name and "Unmasked" in name,
             ATARI_ENVS,
         ),
     )
-    assert len(non_masked_environments) == 0
+    assert len(unmasked_space_invader_environments) > 0
+
+
+def test_atari_unmasked_env_naming():
+    """Tests that all unmasked Atari envs have the appropriate name qualifier."""
+    noncompliant_envs = [
+        (_get_score_region(name) is None and "Unmasked" not in name)
+        for name in ATARI_ENVS
+    ]
+    assert len(noncompliant_envs) == 0
 
 
 @pytest.mark.parametrize("env_name", ENV_NAMES)

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -94,7 +94,7 @@ def test_make_unsupported_masked_atari_env_throws_error():
 def test_atari_masks_satisfy_spec():
     """Tests that all Atari masks satisfy the spec."""
     masks_satisfy_spec = [
-        mask["x"][0] < mask["x"][1] and mask["y"][0] < mask["y"][1]
+        mask.x[0] < mask.x[1] and mask.y[0] < mask.y[1]
         for env_regions in SCORE_REGIONS.values()
         for mask in env_regions
     ]

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -72,10 +72,12 @@ def test_atari_space_invaders():
 
 def test_atari_unmasked_env_naming():
     """Tests that all unmasked Atari envs have the appropriate name qualifier."""
-    noncompliant_envs = [
-        (_get_score_region(name) is None and "Unmasked" not in name)
-        for name in ATARI_ENVS
-    ]
+    noncompliant_envs = list(
+        filter(
+            lambda name: _get_score_region(name) is None and "Unmasked" not in name,
+            ATARI_ENVS,
+        )
+    )
     assert len(noncompliant_envs) == 0
 
 
@@ -103,11 +105,11 @@ class TestEnvs:
         if env_name in ATARI_ENVS:
             # these environments take a while for their non-determinism to show.
             slow_random_envs = [
-                "seals/Bowling-v5",
-                "seals/Frogger-v5",
-                "seals/KingKong-v5",
-                "seals/Koolaid-v5",
-                "seals/NameThisGame-v5",
+                "seals/Bowling-Unmasked-v5",
+                "seals/Frogger-Unmasked-v5",
+                "seals/KingKong-Unmasked-v5",
+                "seals/Koolaid-Unmasked-v5",
+                "seals/NameThisGame-Unmasked-v5",
             ]
             rollout_len = 100 if env_name not in slow_random_envs else 400
             num_seeds = 2 if env_name in ATARI_NO_FRAMESKIP_ENVS else 10

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -7,7 +7,7 @@ from gym.envs import registration
 import pytest
 
 import seals  # noqa: F401 required for env registration
-from seals.atari import SCORE_REGIONS, _get_score_region, _seals_name
+from seals.atari import SCORE_REGIONS, _get_score_region, _seals_name, make_atari_env
 from seals.testing import envs
 
 ENV_NAMES: List[str] = [
@@ -79,6 +79,16 @@ def test_atari_unmasked_env_naming():
         ),
     )
     assert len(noncompliant_envs) == 0
+
+
+def test_make_unsupported_masked_atari_env_throws_error():
+    """Tests that making an unsupported masked Atari env throws an error."""
+    match_str = (
+        "Requested environment does not yet support masking. "
+        "See https://github.com/HumanCompatibleAI/seals/issues/61."
+    )
+    with pytest.raises(ValueError, match=match_str):
+        make_atari_env("ALE/Bowling-v5", masked=True)
 
 
 def test_atari_masks_satisfy_spec():

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -7,7 +7,7 @@ from gym.envs import registration
 import pytest
 
 import seals  # noqa: F401 required for env registration
-from seals.atari import _seals_name
+from seals.atari import _get_score_region, _seals_name
 from seals.testing import envs
 
 ENV_NAMES: List[str] = [
@@ -54,6 +54,17 @@ def test_atari_space_invaders():
         ),
     )
     assert len(space_invader_environments) > 0
+
+
+def test_no_atari_unmasked():
+    """Tests that we only load Atari envs with score masking implemented."""
+    non_masked_environments = list(
+        filter(
+            lambda name: _get_score_region(name) is None,
+            ATARI_ENVS,
+        ),
+    )
+    assert len(non_masked_environments) == 0
 
 
 @pytest.mark.parametrize("env_name", ENV_NAMES)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -2,9 +2,20 @@
 
 import collections
 
+import gym
 import numpy as np
+import pytest
 
-from seals import util
+from seals import GYM_ATARI_ENV_SPECS, util
+
+
+def test_mask_score_wrapper_enforces_spec():
+    """Test that MaskScoreWrapper enforces the spec."""
+    atari_env = gym.make(GYM_ATARI_ENV_SPECS[0].id)
+    with pytest.raises():
+        util.MaskScoreWrapper(atari_env, [dict(x=(0, 1), y=(1, 0))])
+    with pytest.raises():
+        util.MaskScoreWrapper(atari_env, [dict(x=(1, 0), y=(0, 1))])
 
 
 def test_sample_distribution():

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -14,9 +14,9 @@ def test_mask_score_wrapper_enforces_spec():
     atari_env = gym.make(GYM_ATARI_ENV_SPECS[0].id)
     desired_error_message = 'Invalid region: "x" and "y" must be increasing.'
     with pytest.raises(ValueError, match=desired_error_message):
-        util.MaskScoreWrapper(atari_env, [dict(x=(0, 1), y=(1, 0))])
+        util.MaskScoreWrapper(atari_env, [util.BoxRegion(x=(0, 1), y=(1, 0))])
     with pytest.raises(ValueError, match=desired_error_message):
-        util.MaskScoreWrapper(atari_env, [dict(x=(1, 0), y=(0, 1))])
+        util.MaskScoreWrapper(atari_env, [util.BoxRegion(x=(1, 0), y=(0, 1))])
 
 
 def test_sample_distribution():

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -12,9 +12,10 @@ from seals import GYM_ATARI_ENV_SPECS, util
 def test_mask_score_wrapper_enforces_spec():
     """Test that MaskScoreWrapper enforces the spec."""
     atari_env = gym.make(GYM_ATARI_ENV_SPECS[0].id)
-    with pytest.raises():
+    desired_error_message = 'Invalid region: "x" and "y" must be increasing.'
+    with pytest.raises(ValueError, match=desired_error_message):
         util.MaskScoreWrapper(atari_env, [dict(x=(0, 1), y=(1, 0))])
-    with pytest.raises():
+    with pytest.raises(ValueError, match=desired_error_message):
         util.MaskScoreWrapper(atari_env, [dict(x=(1, 0), y=(0, 1))])
 
 


### PR DESCRIPTION
Fixes #61 

Added score masking to the seven atari environments from the RLHF paper. I used a black background to cover the score, to cover enemy ship count for BeamRider, and cover the speedometer for Enduro.

Note that the number of lives is unmasked. This matches the original implementation in the RLHF paper. However, it seems that episode boundaries could be inferred from there. What do we think about this choice?

![image](https://user-images.githubusercontent.com/3607129/194654826-04fad12f-9723-4f59-aa4a-0579bbee374c.png)