### PR TITLE
 Update `sphinxcontrib-napoleon` to `sphinx.ext.napoleon`

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ pip install -e .[dev]  # install extra tools useful for development
 We follow a PEP8 code style with line length 88, and typically follow the [Google Code Style Guide](http://google.github.io/styleguide/pyguide.html),
 but defer to PEP8 where they conflict. We use the `black` autoformatter to avoid arguing over formatting.
 Docstrings follow the Google docstring convention defined [here](http://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings),
-with an extensive example in the [Sphinx docs](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
+with an extensive example in the [Sphinx docs](https://www.sphinx-doc.org/en/master/usage/extensions/example_google.html).
 
 All PRs must pass linting via the `ci/code_checks.sh` script. It is convenient to install this as a commit hook:
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,18 +22,15 @@ version = metadata.version("seals")
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    "sphinxcontrib.napoleon",
     "sphinx.ext.autodoc",
     "sphinx_autodoc_typehints",
     "sphinx.ext.autosummary",
     "sphinx.ext.mathjax",
+    "sphinx.ext.napoleon",
     "sphinx.ext.viewcode",
     "sphinx_rtd_theme",
 ]
 autodoc_mock_imports = ["mujoco_py"]
-
-napoleon_google_docstring = True
-napoleon_numpy_docstring = False
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/setup.py
+++ b/setup.py
@@ -123,7 +123,6 @@ DOCS_REQUIRE = [
     "sphinx",
     "sphinx-autodoc-typehints",
     "sphinx-rtd-theme",
-    "sphinxcontrib-napoleon",
 ]
 
 


### PR DESCRIPTION
`sphinxcontrib-napoleon` is obsolete and also breaks with Python 3.10

```
napoleon_google_docstring = True
napoleon_numpy_docstring = False
```
are defaults in `sphinx.ext.napoleon` so I removed them (but there may still be value in explicitly mentioning them)

The only remaining reference is a link in the README to an example of style guide: https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html but if there is a better example that could also be replaced