### PR TITLE
Don't override terminal observation when using AutoResetWrapper

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -124,7 +124,7 @@ TESTS_REQUIRE = [
 ]
 DOCS_REQUIRE = [
     "sphinx",
-    "sphinx-autodoc-typehints",
+    "sphinx-autodoc-typehints>=1.21.5",
     "sphinx-rtd-theme",
 ]
 

--- a/src/seals/util.py
+++ b/src/seals/util.py
@@ -9,6 +9,7 @@ import numpy as np
 
 class AutoResetWrapper(gym.Wrapper):
     """Hides done=True and auto-resets at the end of each episode.
+
     Depending on the flag 'discard_terminal_observation', either discards the terminal
     observation or pads with an additional 'reset transition'. The latter is the default
     behavior.
@@ -22,29 +23,33 @@ class AutoResetWrapper(gym.Wrapper):
         Args:
             env: The environment to wrap.
             discard_terminal_observation: Defaults to False. If True, the terminal
-            observation is discarded and the environment is reset immediately. The
-            returned observation will then be the start of the next episode. The
-            overridden observation is stored in `info["terminal_observation"]`.
-            If False, the terminal observation is returned and the environment is reset
-            in the next step.
+                observation is discarded and the environment is reset immediately. The
+                returned observation will then be the start of the next episode. The
+                overridden observation is stored in `info["terminal_observation"]`.
+                If False, the terminal observation is returned and the environment is
+                reset in the next step.
         """
         super().__init__(env)
         self.discard_terminal_observation = discard_terminal_observation
         self.previous_done = False  # Whether the previous step returned done=True.
 
     def step(self, action):
-        """When done=True, returns done=False. Then, depending on whether we are
-        discarding the terminal observation, either resets the environment and discards,
+        """When done=True, returns done=False, then reset depending on flag.
+
+        Depending on whether we are discarding the terminal observation,
+        either resets the environment and discards,
         or returns the terminal observation, and then uses the next step to reset the
-        environment, after which steps will be performed as normal."""
+        environment, after which steps will be performed as normal.
+        """
         if self.discard_terminal_observation:
             return self._step_discard(action)
         else:
             return self._step_pad(action)
 
     def _step_pad(self, action):
-        """When done=True, returns done=False instead and returns the terminal
-        observation. The agent will then usually be asked to perform an action based on
+        """When done=True, return done=False instead and return the terminal obs.
+
+        The agent will then usually be asked to perform an action based on
         the terminal observation. In the next step, this final action will be ignored
         to instead reset the environment and return the initial observation of the new
         episode.

--- a/src/seals/util.py
+++ b/src/seals/util.py
@@ -8,9 +8,65 @@ import numpy as np
 
 
 class AutoResetWrapper(gym.Wrapper):
-    """Hides done=True and auto-resets at the end of each episode."""
+    """Hides done=True and auto-resets at the end of each episode.
+    Depending on the flag 'discard_terminal_observation', either discards the terminal
+    observation or pads with an additional 'reset transition'. The latter is the default
+    behavior.
+    In the latter case, the action taken during the 'reset transition' will not have an
+    effect, the reward will always be 0.0, and info an empty dictionary.
+    """
+
+    def __init__(self, env, discard_terminal_observation=False):
+        """Builds the wrapper.
+
+        Args:
+            env: The environment to wrap.
+            discard_terminal_observation: Defaults to False. If True, the terminal
+            observation is discarded and the environment is reset immediately. The
+            returned observation will then be the start of the next episode. The
+            overridden observation is stored in `info["terminal_observation"]`.
+            If False, the terminal observation is returned and the environment is reset
+            in the next step.
+        """
+        super().__init__(env)
+        self.discard_terminal_observation = discard_terminal_observation
+        self.previous_done = False  # Whether the previous step returned done=True.
 
     def step(self, action):
+        """When done=True, returns done=False. Then, depending on whether we are
+        discarding the terminal observation, either resets the environment and discards,
+        or returns the terminal observation, and then uses the next step to reset the
+        environment, after which steps will be performed as normal."""
+        if self.discard_terminal_observation:
+            return self._step_discard(action)
+        else:
+            return self._step_pad(action)
+
+    def _step_pad(self, action):
+        """When done=True, returns done=False instead and returns the terminal
+        observation. The agent will then usually be asked to perform an action based on
+        the terminal observation. In the next step, this final action will be ignored
+        to instead reset the environment and return the initial observation of the new
+        episode.
+
+        Some potential caveats:
+        - The underlying environment will perform fewer steps than the wrapped
+          environment.
+        - The number of steps the agent performs and the number of steps recorded in the
+          underlying environment will not match, which could cause issues if these are
+          assumed to be the same.
+        """
+        if self.previous_done:
+            self.previous_done = False
+            # This transition will only reset the environment, the action is ignored.
+            return self.env.reset(), 0.0, False, {}
+
+        obs, rew, done, info = self.env.step(action)
+        if done:
+            self.previous_done = True
+        return obs, rew, False, info
+
+    def _step_discard(self, action):
         """When done=True, returns done=False instead and automatically resets.
 
         When an automatic reset happens, the observation from reset is returned,

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -7,12 +7,72 @@ from seals import util
 from seals.testing import envs
 
 
-def test_auto_reset_wrapper(episode_length=3, n_steps=100, n_manual_reset=2):
+def test_auto_reset_wrapper_pad(episode_length=3, n_steps=100, n_manual_reset=2):
     """Check that AutoResetWrapper returns correct values from step and reset.
 
+    AutoResetWrapper that pads trajectory with an extra transition containing the
+    terminal observations.
+    Also check that calls to .reset() do not interfere with automatic resets.
+    Due to the padding the number of steps counted inside the environment and the number
+    of steps performed outside the environment, i.e. the number of actions performed,
+    will differ. This test checks that this difference is consistent.
+    """
+    env = util.AutoResetWrapper(
+        envs.CountingEnv(episode_length=episode_length),
+        discard_terminal_observation=False,
+    )
+
+    for _ in range(n_manual_reset):
+        obs = env.reset()
+        assert obs == 0
+
+        # We count the number of episodes, so we can sanity check the padding.
+        num_episodes = 0
+        next_episode_end = episode_length
+        for t in range(1, n_steps + 1):
+            act = env.action_space.sample()
+            obs, rew, done, info = env.step(act)
+
+            # AutoResetWrapper overrides all done signals.
+            assert done is False
+
+            if t == next_episode_end:
+                # Unlike the AutoResetWrapper that discards terminal observations,
+                # here the final observation is returned directly, and is not stored
+                # in the info dict.
+                # Due to padding, for every episode the final observation is offest from
+                # the outer step by one.
+                assert obs == (t - num_episodes) / (num_episodes + 1)
+                assert rew == episode_length * 10
+            if t == next_episode_end + 1:
+                num_episodes += 1
+                # Because the final step returned the final observation, the initial
+                # obs of the next episode is returned in this additional step.
+                assert obs == 0
+                # Consequently, the next episode end is one step later, so it is
+                # episode_length steps from now.
+                next_episode_end = t + episode_length
+
+                # Reward of the 'reset transition' is fixed to be 0.
+                assert rew == 0
+
+                # Sanity check padding. Padding should be 1 for each past episode.
+                assert (
+                    next_episode_end
+                    == (num_episodes + 1) * episode_length + num_episodes
+                )
+
+
+def test_auto_reset_wrapper_discard(episode_length=3, n_steps=100, n_manual_reset=2):
+    """Check that AutoResetWrapper returns correct values from step and reset.
+
+    Tests for AutoResetWrapper that discards terminal observations.
     Also check that calls to .reset() do not interfere with automatic resets.
     """
-    env = util.AutoResetWrapper(envs.CountingEnv(episode_length=episode_length))
+    env = util.AutoResetWrapper(
+        envs.CountingEnv(episode_length=episode_length),
+        discard_terminal_observation=True,
+    )
 
     for _ in range(n_manual_reset):
         obs = env.reset()

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -40,7 +40,7 @@ def test_auto_reset_wrapper_pad(episode_length=3, n_steps=100, n_manual_reset=2)
                 # Unlike the AutoResetWrapper that discards terminal observations,
                 # here the final observation is returned directly, and is not stored
                 # in the info dict.
-                # Due to padding, for every episode the final observation is offest from
+                # Due to padding, for every episode the final observation is offset from
                 # the outer step by one.
                 assert obs == (t - num_episodes) / (num_episodes + 1)
                 assert rew == episode_length * 10


### PR DESCRIPTION
In general, the total number of observations in an episode is always 1 + the number of transitions/actions, because there is always a final next_state observation, which an agent does _not_ act on. The AutoResetWrapper effectively combines several of the episodes of the underlying environment into a single continuing episode. 
`gym` does not anticipate this use case. It will only return a single observation per transition in addition to the very first observation that gets passed the agent, which is generally accessed by calling `.reset()` after an episode is done. Consequently, if we combine n episodes, the question remains how to handle these n-1 extra observations. This PR modifies the AutoResetWrapper to provide two modes with the following behavior.
- Ignore the terminal observation (This is the behavior of AutoResetWrapper prior to this PR):
  - When the environment is reset, we simply ignore the terminal observation, save it in the info dict for reference, and return the next observation, which is the first obs of the next episode (the obs returned by the reset).
  - One consequence of this is that the final _transition_ of an episode will be one where the reset of the env can be seen in the change of obs to next_obs. This might leak information somewhat to a reward model, especially if the reward is generally provided at the end of the episode (such as in coinrun). Although, prematurely ending an episode without or with a different reward should somewhat lessen this effect.
- The new behavior, which amounts to padding the trajectory with an additional transition that happens after the original terminal transition and is dedicated to switching from the end of the previous to the start of the next episode.
  - To hopefully help clarify what I mean by this: next_state is the returned value of step. Generally in gym, we override the final next_step when we call reset. Using this behavior, we don’t override anything, instead, we return the final obs as usual and then have an additional timestep that ends in returning the initial obs of the next episode.
  - For this added timestep I decided to simply return an empty info dict and reward 0.
  - This added transition will still noticeably have observations that contain information regarding the reset of the env. However, this particular transition will never contain meaningful information about the reward of the wrapped environment.

I chose to use the latter behavior as default since it presumably leaks less information.

This PR also has a test case for this new behavior.