### PR TITLE
Migrate to gymnasium maintaining python 3.8 compatibility 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ orbs:
 
 defaults: &defaults
   docker:
-    - image: humancompatibleai/seals:base
+    - image: humancompatibleai/seals:base-alpha
       auth:
         username: $DOCKERHUB_USERNAME
         password: $DOCKERHUB_PASSWORD

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ commands:
       # released that you want to upgrade to, without mandating the newer version in setup.py.
       - restore_cache:
           keys:
-            - v2-dependencies-{{ checksum "setup.py" }}
+            - v2-dependencies-{{ checksum "setup.py" }}-{{ checksum "ci/build_venv.sh" }}
 
       # Create virtual environment and install dependencies using `ci/build_venv.sh`.
       # `mujoco_py` needs a MuJoCo key, so download that first.
@@ -64,7 +64,7 @@ commands:
       - save_cache:
           paths:
             - /venv
-          key: v2-dependencies-{{ checksum "setup.py" }}
+          key: v2-dependencies-{{ checksum "setup.py" }}-{{ checksum "ci/build_venv.sh" }}
 
       # Install seals.
       # Note we install the source distribution, not in developer mode (`pip install -e`).

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # base stage contains just binary dependencies.
 # This is used in the CI build.
-FROM nvidia/cuda:10.0-runtime-ubuntu18.04 AS base
+FROM nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu20.04 AS base
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN    apt-get update -q \
@@ -9,6 +9,7 @@ RUN    apt-get update -q \
     curl \
     ffmpeg \
     git \
+    ssh \
     libgl1-mesa-dev \
     libgl1-mesa-glx \
     libglew-dev \

--- a/README.md
+++ b/README.md
@@ -7,35 +7,35 @@
 
 **Status**: early beta.
 
-_seals_, the Suite of Environments for Algorithms that Learn Specifications, is a toolkit for
+*seals*, the Suite of Environments for Algorithms that Learn Specifications, is a toolkit for
 evaluating specification learning algorithms, such as reward or imitation learning. The
 environments are compatible with [Gym](https://github.com/openai/gym), but are designed
 to test algorithms that learn from user data, without requiring a procedurally specified
 reward function.
 
-There are two types of environments in _seals_:
+There are two types of environments in *seals*:
 
-- **Diagnostic Tasks** which test individual facets of algorithm performance in isolation.
-- **Renovated Environments**, adaptations of widely-used benchmarks such as MuJoCo continuous
-  control tasks and Atari games to be suitable for specification learning benchmarks. In particular,
-  we remove any side-channel sources of reward information from MuJoCo tasks, and give Atari games constant-length episodes (although most Atari environments have observations that include the score).
+  - **Diagnostic Tasks** which test individual facets of algorithm performance in isolation.
+  - **Renovated Environments**, adaptations of widely-used benchmarks such as MuJoCo continuous
+      control tasks and Atari games to be suitable for specification learning benchmarks. In particular, 
+      we remove any side-channel sources of reward information from MuJoCo tasks, and give Atari games constant-length episodes (although most Atari environments have observations that include the score).
 
-_seals_ is under active development and we intend to add more categories of tasks soon.
-
+*seals* is under active development and we intend to add more categories of tasks soon.
+ 
 You may also be interested in our sister project [imitation](https://github.com/humancompatibleai/imitation/),
 providing implementations of a variety of imitation and reward learning algorithms.
 
-Check out our [documentation](https://seals.readthedocs.io/en/latest/) for more information about _seals_.
+Check out our [documentation](https://seals.readthedocs.io/en/latest/) for more information about *seals*.
 
 # Quickstart
 
 To install the latest release from PyPI, run:
-
+ 
 ```bash
 pip install seals
 ```
 
-All _seals_ environments are available in the Gym registry. Simply import it and then use as you
+All *seals* environments are available in the Gym registry. Simply import it and then use as you
 would with your usual RL or specification learning algroithm:
 
 ```python
@@ -86,7 +86,7 @@ for type checking.
 ## Workflow
 
 Trivial changes (e.g. typo fixes) may be made directly by maintainers. Any non-trivial changes
-must be proposed in a PR and approved by at least one maintainer. PRs must pass the continuous
+must be proposed in a PR and approved by at least one maintainer. PRs must pass the continuous 
 integration tests (CircleCI linting, type checking, unit tests and CodeCov) to be merged.
 
 It is often helpful to open an issue before proposing a PR, to allow for discussion of the design

--- a/README.md
+++ b/README.md
@@ -7,39 +7,39 @@
 
 **Status**: early beta.
 
-*seals*, the Suite of Environments for Algorithms that Learn Specifications, is a toolkit for
+_seals_, the Suite of Environments for Algorithms that Learn Specifications, is a toolkit for
 evaluating specification learning algorithms, such as reward or imitation learning. The
 environments are compatible with [Gym](https://github.com/openai/gym), but are designed
 to test algorithms that learn from user data, without requiring a procedurally specified
 reward function.
 
-There are two types of environments in *seals*:
+There are two types of environments in _seals_:
 
-  - **Diagnostic Tasks** which test individual facets of algorithm performance in isolation.
-  - **Renovated Environments**, adaptations of widely-used benchmarks such as MuJoCo continuous
-      control tasks and Atari games to be suitable for specification learning benchmarks. In particular, 
-      we remove any side-channel sources of reward information from MuJoCo tasks, and give Atari games constant-length episodes (although most Atari environments have observations that include the score).
+- **Diagnostic Tasks** which test individual facets of algorithm performance in isolation.
+- **Renovated Environments**, adaptations of widely-used benchmarks such as MuJoCo continuous
+  control tasks and Atari games to be suitable for specification learning benchmarks. In particular,
+  we remove any side-channel sources of reward information from MuJoCo tasks, and give Atari games constant-length episodes (although most Atari environments have observations that include the score).
 
-*seals* is under active development and we intend to add more categories of tasks soon.
- 
+_seals_ is under active development and we intend to add more categories of tasks soon.
+
 You may also be interested in our sister project [imitation](https://github.com/humancompatibleai/imitation/),
 providing implementations of a variety of imitation and reward learning algorithms.
 
-Check out our [documentation](https://seals.readthedocs.io/en/latest/) for more information about *seals*.
+Check out our [documentation](https://seals.readthedocs.io/en/latest/) for more information about _seals_.
 
 # Quickstart
 
 To install the latest release from PyPI, run:
- 
+
 ```bash
 pip install seals
 ```
 
-All *seals* environments are available in the Gym registry. Simply import it and then use as you
+All _seals_ environments are available in the Gym registry. Simply import it and then use as you
 would with your usual RL or specification learning algroithm:
 
 ```python
-import gym
+import gymnasium as gym
 import seals
 
 env = gym.make('seals/CartPole-v0')
@@ -86,7 +86,7 @@ for type checking.
 ## Workflow
 
 Trivial changes (e.g. typo fixes) may be made directly by maintainers. Any non-trivial changes
-must be proposed in a PR and approved by at least one maintainer. PRs must pass the continuous 
+must be proposed in a PR and approved by at least one maintainer. PRs must pass the continuous
 integration tests (CircleCI linting, type checking, unit tests and CodeCov) to be merged.
 
 It is often helpful to open an issue before proposing a PR, to allow for discussion of the design

--- a/ci/Xdummy-entrypoint.py
+++ b/ci/Xdummy-entrypoint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 # Adapted from https://github.com/openai/mujoco-py/blob/master/vendor/Xdummy-entrypoint
 # Copyright OpenAI; MIT License

--- a/ci/build_venv.sh
+++ b/ci/build_venv.sh
@@ -9,4 +9,5 @@ fi
 
 virtualenv -p python3.8 ${venv}
 source ${venv}/bin/activate
+pip install --upgrade pip  # Ensure we have the newest pip
 pip install .[cpu,docs,mujoco,test]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,8 @@ build-backend = "setuptools.build_meta"
 target-version = ["py38"]
 
 [[tool.mypy.overrides]]
-module = [
-    "gym.*",
-    "setuptools_scm.*",
-]
+module = ["gym.*", "setuptools_scm.*"]
 ignore_missing_imports = true
+
+[tool.ruff]
+select = ["E", "F"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,3 @@ target-version = ["py38"]
 [[tool.mypy.overrides]]
 module = ["gym.*", "setuptools_scm.*"]
 ignore_missing_imports = true
-
-[tool.ruff]
-select = ["E", "F"]

--- a/setup.py
+++ b/setup.py
@@ -116,7 +116,7 @@ TESTS_REQUIRE = [
     "pytype",
     "stable-baselines3>=0.9.0",
     "setuptools_scm~=7.0.5",
-    "gymnasium[classic-control]",
+    "gymnasium[classic-control,mujoco]",
     *ATARI_REQUIRE,
 ]
 DOCS_REQUIRE = [

--- a/setup.py
+++ b/setup.py
@@ -91,6 +91,7 @@ ATARI_REQUIRE = [
     "ale-py==0.7.4",
     "pillow",
     "autorom[accept-rom-license]~=0.4.2",
+    "shimmy[atari] >=0.1.0,<1.0",
 ]
 TESTS_REQUIRE = [
     # remove pin once https://github.com/nedbat/coveragepy/issues/881 fixed

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ def get_readme() -> str:
 
 ATARI_REQUIRE = [
     "opencv-python",
-    "ale-py==0.7.4",
+    "ale-py~=0.8.1",
     "pillow",
     "autorom[accept-rom-license]~=0.4.2",
     "shimmy[atari] >=0.1.0,<1.0",

--- a/setup.py
+++ b/setup.py
@@ -94,9 +94,8 @@ ATARI_REQUIRE = [
     "shimmy[atari] >=0.1.0,<1.0",
 ]
 TESTS_REQUIRE = [
-    # remove pin once https://github.com/nedbat/coveragepy/issues/881 fixed
     "black",
-    "coverage==4.5.4",
+    "coverage~=4.5.4",
     "codecov",
     "codespell",
     "darglint>=1.5.6",
@@ -117,10 +116,7 @@ TESTS_REQUIRE = [
     "pytype",
     "stable-baselines3>=0.9.0",
     "setuptools_scm~=7.0.5",
-    # We'd like to specify `gymnasium[classic-control]`, but this is a no-op when
-    # gymnasium is already installed. See https://github.com/pypa/pip/issues/4957 for
-    # issue.
-    "pygame>=2.1.3",
+    "gymnasium[classic-control]",
     *ATARI_REQUIRE,
 ]
 DOCS_REQUIRE = [
@@ -148,9 +144,7 @@ setup(
         "dev": ["ipdb", "jupyter", *TESTS_REQUIRE, *DOCS_REQUIRE],
         "docs": DOCS_REQUIRE,
         "test": TESTS_REQUIRE,
-        # We'd like to specify `gymnasium[mujoco]`, but this is a no-op when gymnasium
-        # is already installed. See https://github.com/pypa/pip/issues/4957 for issue.
-        "mujoco": ["mujoco", "imageio"],
+        "mujoco": ["gymnasium[mujoco]"],
         "atari": ATARI_REQUIRE,
     },
     url="https://github.com/HumanCompatibleAI/benchmark-environments",

--- a/setup.py
+++ b/setup.py
@@ -117,6 +117,10 @@ TESTS_REQUIRE = [
     "pytype",
     "stable-baselines3>=0.9.0",
     "setuptools_scm~=7.0.5",
+    # We'd like to specify `gymnasium[classic-control]`, but this is a no-op when
+    # gymnasium is already installed. See https://github.com/pypa/pip/issues/4957 for
+    # issue.
+    "pygame>=2.1.3",
     *ATARI_REQUIRE,
 ]
 DOCS_REQUIRE = [
@@ -144,8 +148,8 @@ setup(
         "dev": ["ipdb", "jupyter", *TESTS_REQUIRE, *DOCS_REQUIRE],
         "docs": DOCS_REQUIRE,
         "test": TESTS_REQUIRE,
-        # We'd like to specify `gymnasium[mujoco]`, but this is a no-op when Gym is already
-        # installed. See https://github.com/pypa/pip/issues/4957 for issue.
+        # We'd like to specify `gymnasium[mujoco]`, but this is a no-op when gymnasium
+        # is already installed. See https://github.com/pypa/pip/issues/4957 for issue.
         "mujoco": ["mujoco", "imageio"],
         "atari": ATARI_REQUIRE,
     },

--- a/setup.py
+++ b/setup.py
@@ -115,10 +115,6 @@ TESTS_REQUIRE = [
     "pytest-xdist",
     "pytype",
     "stable-baselines3>=0.9.0",
-    # TODO(adam): remove pyglet pin once Gym upgraded to >0.21
-    # Workaround for https://github.com/openai/gym/issues/2986
-    # Discussed in https://github.com/HumanCompatibleAI/imitation/pull/603
-    "pyglet==1.5.27",
     "setuptools_scm~=7.0.5",
     *ATARI_REQUIRE,
 ]
@@ -140,7 +136,7 @@ setup(
     packages=find_packages("src"),
     package_dir={"": "src"},
     package_data={"seals": ["py.typed"]},
-    install_requires=["gym", "numpy"],
+    install_requires=["gymnasium", "numpy"],
     tests_require=TESTS_REQUIRE,
     extras_require={
         # recommended packages for development
@@ -149,7 +145,7 @@ setup(
         "test": TESTS_REQUIRE,
         # We'd like to specify `gym[mujoco]`, but this is a no-op when Gym is already
         # installed. See https://github.com/pypa/pip/issues/4957 for issue.
-        "mujoco": ["mujoco_py>=1.50, <2.0", "imageio"],
+        "mujoco": ["mujoco", "imageio"],
         "atari": ATARI_REQUIRE,
     },
     url="https://github.com/HumanCompatibleAI/benchmark-environments",

--- a/setup.py
+++ b/setup.py
@@ -143,7 +143,7 @@ setup(
         "dev": ["ipdb", "jupyter", *TESTS_REQUIRE, *DOCS_REQUIRE],
         "docs": DOCS_REQUIRE,
         "test": TESTS_REQUIRE,
-        # We'd like to specify `gym[mujoco]`, but this is a no-op when Gym is already
+        # We'd like to specify `gymnasium[mujoco]`, but this is a no-op when Gym is already
         # installed. See https://github.com/pypa/pip/issues/4957 for issue.
         "mujoco": ["mujoco", "imageio"],
         "atari": ATARI_REQUIRE,

--- a/src/seals/__init__.py
+++ b/src/seals/__init__.py
@@ -2,10 +2,10 @@
 
 from importlib import metadata
 
-import gym
+import gymnasium as gym
 
-from seals import atari, util
 import seals.diagnostics  # noqa: F401
+from seals import atari, util
 
 try:
     __version__ = metadata.version("seals")
@@ -38,5 +38,5 @@ for env_base in ["Ant", "HalfCheetah", "Hopper", "Humanoid", "Swimmer", "Walker2
 
 # Atari
 
-GYM_ATARI_ENV_SPECS = list(filter(atari._supported_atari_env, gym.envs.registry.all()))
+GYM_ATARI_ENV_SPECS = list(filter(atari._supported_atari_env, gym.registry.values()))
 atari.register_atari_envs(GYM_ATARI_ENV_SPECS)

--- a/src/seals/__init__.py
+++ b/src/seals/__init__.py
@@ -4,8 +4,8 @@ from importlib import metadata
 
 import gymnasium as gym
 
-import seals.diagnostics  # noqa: F401
 from seals import atari, util
+import seals.diagnostics  # noqa: F401
 
 try:
     __version__ = metadata.version("seals")

--- a/src/seals/__init__.py
+++ b/src/seals/__init__.py
@@ -31,9 +31,9 @@ gym.register(
 
 for env_base in ["Ant", "HalfCheetah", "Hopper", "Humanoid", "Swimmer", "Walker2d"]:
     gym.register(
-        id=f"seals/{env_base}-v0",
+        id=f"seals/{env_base}-v1",
         entry_point=f"seals.mujoco:{env_base}Env",
-        max_episode_steps=util.get_gym_max_episode_steps(f"{env_base}-v3"),
+        max_episode_steps=util.get_gym_max_episode_steps(f"{env_base}-v4"),
     )
 
 # Atari

--- a/src/seals/atari.py
+++ b/src/seals/atari.py
@@ -2,7 +2,8 @@
 
 from typing import Dict, Iterable, Optional
 
-import gym
+import gymnasium as gym
+from gymnasium.envs.registration import EnvSpec
 
 from seals.util import (
     AutoResetWrapper,
@@ -37,7 +38,7 @@ def _get_score_region(atari_env_id: str) -> Optional[MaskedRegionSpecifier]:
 
 def make_atari_env(atari_env_id: str, masked: bool) -> gym.Env:
     """Fixed-length, optionally masked-score variant of a given Atari environment."""
-    env = AutoResetWrapper(gym.make(atari_env_id))
+    env: gym.Env = AutoResetWrapper(gym.make(atari_env_id))
 
     if masked:
         score_region = _get_score_region(atari_env_id)
@@ -59,15 +60,15 @@ def _not_ram_or_det(env_id: str) -> bool:
     after_slash = slash_separated[-1]
     hyphen_separated = after_slash.split("-")
     assert len(hyphen_separated) > 1
-    not_ram = not ("ram" in hyphen_separated[1])
-    not_deterministic = not ("Deterministic" in env_id)
+    not_ram = "ram" not in hyphen_separated[1]
+    not_deterministic = "Deterministic" not in env_id
     return not_ram and not_deterministic
 
 
-def _supported_atari_env(gym_spec: gym.envs.registration.EnvSpec) -> bool:
+def _supported_atari_env(gym_spec: EnvSpec) -> bool:
     """Checks if a gym Atari environment is one of the ones we will support."""
     is_atari = gym_spec.entry_point == "gym.envs.atari:AtariEnv"
-    v5_and_plain = gym_spec.id.endswith("-v5") and not ("NoFrameskip" in gym_spec.id)
+    v5_and_plain = gym_spec.id.endswith("-v5") and "NoFrameskip" not in gym_spec.id
     v4_and_no_frameskip = gym_spec.id.endswith("-v4") and "NoFrameskip" in gym_spec.id
     return (
         is_atari
@@ -76,7 +77,7 @@ def _supported_atari_env(gym_spec: gym.envs.registration.EnvSpec) -> bool:
     )
 
 
-def _seals_name(gym_spec: gym.envs.registration.EnvSpec, masked: bool) -> str:
+def _seals_name(gym_spec: EnvSpec, masked: bool) -> str:
     """Makes a Gym ID for an Atari environment in the seals namespace."""
     slash_separated = gym_spec.id.split("/")
     name = "seals/" + slash_separated[-1]
@@ -88,7 +89,7 @@ def _seals_name(gym_spec: gym.envs.registration.EnvSpec, masked: bool) -> str:
 
 
 def register_atari_envs(
-    gym_atari_env_specs: Iterable[gym.envs.registration.EnvSpec],
+    gym_atari_env_specs: Iterable[EnvSpec],
 ) -> None:
     """Register masked and unmasked wrapped gym Atari environments."""
 

--- a/src/seals/atari.py
+++ b/src/seals/atari.py
@@ -67,7 +67,7 @@ def _not_ram_or_det(env_id: str) -> bool:
 
 def _supported_atari_env(gym_spec: EnvSpec) -> bool:
     """Checks if a gym Atari environment is one of the ones we will support."""
-    is_atari = gym_spec.entry_point == "gym.envs.atari:AtariEnv"
+    is_atari = gym_spec.entry_point == "shimmy.atari_env:AtariEnv"
     v5_and_plain = gym_spec.id.endswith("-v5") and "NoFrameskip" not in gym_spec.id
     v4_and_no_frameskip = gym_spec.id.endswith("-v4") and "NoFrameskip" in gym_spec.id
     return (

--- a/src/seals/atari.py
+++ b/src/seals/atari.py
@@ -36,9 +36,9 @@ def _get_score_region(atari_env_id: str) -> Optional[MaskedRegionSpecifier]:
     return SCORE_REGIONS.get(basename)
 
 
-def make_atari_env(atari_env_id: str, masked: bool) -> gym.Env:
+def make_atari_env(atari_env_id: str, masked: bool, *args, **kwargs) -> gym.Env:
     """Fixed-length, optionally masked-score variant of a given Atari environment."""
-    env: gym.Env = AutoResetWrapper(gym.make(atari_env_id))
+    env: gym.Env = AutoResetWrapper(gym.make(atari_env_id, *args, **kwargs))
 
     if masked:
         score_region = _get_score_region(atari_env_id)

--- a/src/seals/base_envs.py
+++ b/src/seals/base_envs.py
@@ -33,7 +33,6 @@ class ResettablePOMDP(
 
     def __init__(self):
         """Build resettable (PO)MDP."""
-
         self._cur_state = None
         self._n_actions_taken = None
 

--- a/src/seals/base_envs.py
+++ b/src/seals/base_envs.py
@@ -16,7 +16,9 @@ ActType = TypeVar("ActType")
 
 
 class ResettablePOMDP(
-    gym.Env[ObsType, ActType], abc.ABC, Generic[StateType, ObsType, ActType],
+    gym.Env[ObsType, ActType],
+    abc.ABC,
+    Generic[StateType, ObsType, ActType],
 ):
     """ABC for POMDPs that are resettable.
 
@@ -138,7 +140,9 @@ class ExposePOMDPStateWrapper(
         self._observation_space = env.state_space
 
     def reset(
-        self, seed: Optional[int] = None, options: Optional[Dict[str, Any]] = None,
+        self,
+        seed: Optional[int] = None,
+        options: Optional[Dict[str, Any]] = None,
     ) -> Tuple[StateType, Dict[str, Any]]:
         """Reset environment and return initial state."""
         _, info = self.env.reset(seed=seed, options=options)
@@ -179,7 +183,8 @@ DiscreteSpaceInt = np.int64
 #  so in theory it should not be instantiated directly.
 #  Not sure why this is not raising an error?
 class BaseTabularModelPOMDP(
-    ResettablePOMDP[DiscreteSpaceInt, ObsType, DiscreteSpaceInt], Generic[ObsType],
+    ResettablePOMDP[DiscreteSpaceInt, ObsType, DiscreteSpaceInt],
+    Generic[ObsType],
 ):
     """Base class for tabular environments with known dynamics.
 
@@ -278,7 +283,9 @@ class BaseTabularModelPOMDP(
         )
 
     def transition(
-        self, state: DiscreteSpaceInt, action: DiscreteSpaceInt,
+        self,
+        state: DiscreteSpaceInt,
+        action: DiscreteSpaceInt,
     ) -> DiscreteSpaceInt:
         """Samples from transition distribution."""
         return DiscreteSpaceInt(
@@ -324,7 +331,9 @@ class BaseTabularModelPOMDP(
 
 
 ObsEntryType = TypeVar(
-    "ObsEntryType", bound=Union[np.floating, np.integer], covariant=True,
+    "ObsEntryType",
+    bound=Union[np.floating, np.integer],
+    covariant=True,
 )
 
 

--- a/src/seals/base_envs.py
+++ b/src/seals/base_envs.py
@@ -168,11 +168,6 @@ class ResettableMDP(
         """Observation space."""
         return self.state_space
 
-    @observation_space.setter
-    def observation_space(self, space: spaces.Space[StateType]):
-        """Set observation space."""
-        self.state_space = space
-
     def obs_from_state(self, state: StateType) -> StateType:
         """Identity since observation == state in an MDP."""
         return state

--- a/src/seals/base_envs.py
+++ b/src/seals/base_envs.py
@@ -16,7 +16,7 @@ ActType = TypeVar("ActType")
 
 
 class ResettablePOMDP(
-    gym.Env[ObsType, ActType], abc.ABC, Generic[StateType, ObsType, ActType]
+    gym.Env[ObsType, ActType], abc.ABC, Generic[StateType, ObsType, ActType],
 ):
     """ABC for POMDPs that are resettable.
 
@@ -139,7 +139,7 @@ class ExposePOMDPStateWrapper(
         self._observation_space = env.state_space
 
     def reset(
-        self, seed: Optional[int] = None, options: Optional[Dict[str, Any]] = None
+        self, seed: Optional[int] = None, options: Optional[Dict[str, Any]] = None,
     ) -> Tuple[StateType, Dict[str, Any]]:
         """Reset environment and return initial state."""
         _, info = self.env.reset(seed=seed, options=options)
@@ -180,7 +180,7 @@ DiscreteSpaceInt = np.int64
 #  so in theory it should not be instantiated directly.
 #  Not sure why this is not raising an error?
 class BaseTabularModelPOMDP(
-    ResettablePOMDP[DiscreteSpaceInt, ObsType, DiscreteSpaceInt], Generic[ObsType]
+    ResettablePOMDP[DiscreteSpaceInt, ObsType, DiscreteSpaceInt], Generic[ObsType],
 ):
     """Base class for tabular environments with known dynamics.
 
@@ -275,18 +275,18 @@ class BaseTabularModelPOMDP(
             util.sample_distribution(
                 self.initial_state_dist,
                 random=self.rand_state,
-            )
+            ),
         )
 
     def transition(
-        self, state: DiscreteSpaceInt, action: DiscreteSpaceInt
+        self, state: DiscreteSpaceInt, action: DiscreteSpaceInt,
     ) -> DiscreteSpaceInt:
         """Samples from transition distribution."""
         return DiscreteSpaceInt(
             util.sample_distribution(
                 self.transition_matrix[state, action],
                 random=self.rand_state,
-            )
+            ),
         )
 
     def reward(
@@ -325,7 +325,7 @@ class BaseTabularModelPOMDP(
 
 
 ObsEntryType = TypeVar(
-    "ObsEntryType", bound=Union[np.floating, np.integer], covariant=True
+    "ObsEntryType", bound=Union[np.floating, np.integer], covariant=True,
 )
 
 

--- a/src/seals/base_envs.py
+++ b/src/seals/base_envs.py
@@ -1,20 +1,23 @@
 """Base environment classes."""
 
 import abc
-from typing import Generic, Optional, Sequence, Tuple, TypeVar
+from typing import Any, Generic, Optional, Tuple, TypeVar
 
-import gym
-from gym import spaces
+import gymnasium as gym
 import numpy as np
+import numpy.typing as npt
+from gymnasium import spaces
 
 from seals import util
 
-State = TypeVar("State")
-Observation = TypeVar("Observation")
-Action = TypeVar("Action")
+StateType = TypeVar("StateType")
+ObsType = TypeVar("ObsType")
+ActType = TypeVar("ActType")
 
 
-class ResettablePOMDP(gym.Env, abc.ABC, Generic[State, Observation, Action]):
+class ResettablePOMDP(
+    gym.Env[ObsType, ActType], abc.ABC, Generic[StateType, ObsType, ActType]
+):
     """ABC for POMDPs that are resettable.
 
     Specifically, these environments provide oracle access to sample from
@@ -23,68 +26,36 @@ class ResettablePOMDP(gym.Env, abc.ABC, Generic[State, Observation, Action]):
     meet these criteria.
     """
 
-    _state_space: gym.Space
-    _observation_space: gym.Space
-    _action_space: gym.Space
-    _cur_state: Optional[State]
+    state_space: spaces.Space[StateType]
+
+    _cur_state: Optional[StateType]
     _n_actions_taken: Optional[int]
 
-    def __init__(
-        self,
-        *,
-        state_space: gym.Space,
-        observation_space: gym.Space,
-        action_space: gym.Space,
-    ):
-        """Build resettable (PO)MDP.
-
-        Args:
-            state_space: gym.Space containing possible states.
-            observation_space: gym.Space containing possible observations.
-            action_space: gym.Space containing possible actions.
-        """
-        self._state_space = state_space
-        self._observation_space = observation_space
-        self._action_space = action_space
+    def __init__(self):
+        """Build resettable (PO)MDP."""
 
         self._cur_state = None
         self._n_actions_taken = None
-        self.seed()
 
     @abc.abstractmethod
-    def initial_state(self) -> State:
+    def initial_state(self) -> StateType:
         """Samples from the initial state distribution."""
 
     @abc.abstractmethod
-    def transition(self, state: State, action: Action) -> State:
+    def transition(self, state: StateType, action: ActType) -> StateType:
         """Samples from transition distribution."""
 
     @abc.abstractmethod
-    def reward(self, state: State, action: Action, new_state: State) -> float:
+    def reward(self, state: StateType, action: ActType, new_state: StateType) -> float:
         """Computes reward for a given transition."""
 
     @abc.abstractmethod
-    def terminal(self, state: State, step: int) -> bool:
+    def terminal(self, state: StateType, step: int) -> bool:
         """Is the state terminal?"""
 
     @abc.abstractmethod
-    def obs_from_state(self, state: State) -> Observation:
+    def obs_from_state(self, state: StateType) -> ObsType:
         """Sample observation for given state."""
-
-    @property
-    def state_space(self) -> gym.Space:
-        """State space. Often same as observation_space, but differs in POMDPs."""
-        return self._state_space
-
-    @property
-    def observation_space(self) -> gym.Space:
-        """Observation space. Return type of reset() and component of step()."""
-        return self._observation_space
-
-    @property
-    def action_space(self) -> gym.Space:
-        """Action space. Parameter type of step()."""
-        return self._action_space
 
     @property
     def n_actions_taken(self) -> int:
@@ -93,34 +64,36 @@ class ResettablePOMDP(gym.Env, abc.ABC, Generic[State, Observation, Action]):
         return self._n_actions_taken
 
     @property
-    def state(self) -> State:
+    def state(self) -> StateType:
         """Current state."""
         assert self._cur_state is not None
         return self._cur_state
 
     @state.setter
-    def state(self, state: State):
+    def state(self, state: StateType):
         """Set current state."""
         if state not in self.state_space:
             raise ValueError(f"{state} not in {self.state_space}")
         self._cur_state = state
 
-    def seed(self, seed=None) -> Sequence[int]:
-        """Set random seed."""
-        if seed is None:
-            # Gym API wants list of seeds to be returned for some reason, so
-            # generate a seed explicitly in this case
-            seed = np.random.randint(0, 1 << 31)
-        self.rand_state = np.random.RandomState(seed)
-        return [seed]
-
-    def reset(self) -> Observation:
+    def reset(
+        self,
+        *,
+        seed: int | None = None,
+        options: dict[str, Any] | None = None,
+    ) -> tuple[ObsType, dict[str, Any]]:  # type: ignore
         """Reset episode and return initial observation."""
+        if options is not None:
+            raise ValueError("Options not supported.")
+
+        super().reset(seed=seed)
         self.state = self.initial_state()
         self._n_actions_taken = 0
-        return self.obs_from_state(self.state)
+        obs = self.obs_from_state(self.state)
+        info: dict[str, Any] = dict()
+        return obs, info
 
-    def step(self, action: Action) -> Tuple[Observation, float, bool, dict]:
+    def step(self, action: ActType) -> Tuple[ObsType, float, bool, bool, dict]:
         """Transition state using given action."""
         if self._cur_state is None or self._n_actions_taken is None:
             raise ValueError("Need to call reset() before first step()")
@@ -133,16 +106,30 @@ class ResettablePOMDP(gym.Env, abc.ABC, Generic[State, Observation, Action]):
         assert obs in self.observation_space
         reward = self.reward(old_state, action, self.state)
         self._n_actions_taken += 1
-        done = self.terminal(self.state, self.n_actions_taken)
+        terminated = self.terminal(self.state, self.n_actions_taken)
+        truncated = False
 
         infos = {"old_state": old_state, "new_state": self._cur_state}
-        return obs, reward, done, infos
+        return obs, reward, terminated, truncated, infos
+
+    @property
+    def rand_state(self) -> np.random.Generator:
+        """Random state."""
+        rand_state = self._np_random
+        if rand_state is None:
+            raise ValueError("Need to call reset() before accessing rand_state")
+        return rand_state
 
 
-class ExposePOMDPStateWrapper(gym.Wrapper, Generic[State, Observation, Action]):
+class ExposePOMDPStateWrapper(
+    gym.Wrapper[StateType, ActType, ObsType, ActType],
+    Generic[StateType, ObsType, ActType],
+):
     """A wrapper that exposes the current state of the POMDP as the observation."""
 
-    def __init__(self, env: ResettablePOMDP[State, Observation, Action]) -> None:
+    env: ResettablePOMDP[StateType, ObsType, ActType]
+
+    def __init__(self, env: ResettablePOMDP[StateType, ObsType, ActType]) -> None:
         """Build wrapper.
 
         Args:
@@ -151,51 +138,50 @@ class ExposePOMDPStateWrapper(gym.Wrapper, Generic[State, Observation, Action]):
         super().__init__(env)
         self._observation_space = env.state_space
 
-    def reset(self) -> State:
+    def reset(
+        self, seed: int | None = None, options: dict[str, Any] | None = None
+    ) -> Tuple[StateType, dict[str, Any]]:
         """Reset environment and return initial state."""
-        self.env.reset()
-        return self.env.state
+        _, info = self.env.reset(seed=seed, options=options)
+        return self.env.state, info
 
-    def step(self, action) -> Tuple[State, float, bool, dict]:
+    def step(self, action) -> Tuple[StateType, float, bool, bool, dict]:
         """Transition state using given action."""
-        obs, reward, done, info = self.env.step(action)
-        return self.env.state, reward, done, info
+        _, reward, terminated, truncated, info = self.env.step(action)
+        return self.env.state, reward, terminated, truncated, info
 
 
 class ResettableMDP(
-    ResettablePOMDP[State, State, Action],
+    ResettablePOMDP[StateType, StateType, ActType],
     abc.ABC,
-    Generic[State, Action],
+    Generic[StateType, ActType],
 ):
     """ABC for MDPs that are resettable."""
 
-    def __init__(
-        self,
-        *,
-        state_space: gym.Space,
-        action_space: gym.Space,
-    ):
-        """Build resettable MDP.
+    @property
+    def observation_space(self) -> spaces.Space[StateType]:
+        """Observation space."""
+        return self.state_space
 
-        Args:
-            state_space: gym.Space containing possible states.
-            action_space: gym.Space containing possible actions.
-        """
-        super().__init__(
-            state_space=state_space,
-            observation_space=state_space,
-            action_space=action_space,
-        )
+    @observation_space.setter
+    def observation_space(self, space: spaces.Space[StateType]):
+        """Set observation space."""
+        self.state_space = space
 
-    def obs_from_state(self, state: State) -> State:
+    def obs_from_state(self, state: StateType) -> StateType:
         """Identity since observation == state in an MDP."""
         return state
+
+
+DiscreteSpaceInt = np.int64
 
 
 # TODO(juan) this does not implement the .render() method,
 #  so in theory it should not be instantiated directly.
 #  Not sure why this is not raising an error?
-class BaseTabularModelPOMDP(ResettablePOMDP[int, Observation, int]):
+class BaseTabularModelPOMDP(
+    ResettablePOMDP[DiscreteSpaceInt, ObsType, DiscreteSpaceInt], Generic[ObsType]
+):
     """Base class for tabular environments with known dynamics.
 
     This is the general class that also allows subclassing for creating
@@ -236,6 +222,8 @@ class BaseTabularModelPOMDP(ResettablePOMDP[int, Observation, int]):
             ValueError: `transition_matrix`, `reward_matrix` or
                 `initial_state_dist` have shapes different to specified above.
         """
+        super().__init__()
+
         # The following matrices should conform to the shapes below:
 
         # transition matrix: n_states x n_actions x n_states
@@ -278,43 +266,42 @@ class BaseTabularModelPOMDP(ResettablePOMDP[int, Observation, int]):
         self.horizon = horizon
         self.initial_state_dist = initial_state_dist
 
-        super().__init__(
-            state_space=self._construct_state_space(),
-            action_space=self._construct_action_space(),
-            observation_space=self._construct_observation_space(),
-        )
+        self.state_space = spaces.Discrete(self.state_dim)
+        self.action_space = spaces.Discrete(self.action_dim)
 
-    def _construct_state_space(self) -> gym.Space:
-        return spaces.Discrete(self.state_dim)
-
-    def _construct_action_space(self) -> gym.Space:
-        return spaces.Discrete(self.action_dim)
-
-    @abc.abstractmethod
-    def _construct_observation_space(self) -> gym.Space:
-        pass  # pragma: no cover
-
-    def initial_state(self) -> int:
+    def initial_state(self) -> DiscreteSpaceInt:
         """Samples from the initial state distribution."""
-        return util.sample_distribution(
-            self.initial_state_dist,
-            random=self.rand_state,
+        return DiscreteSpaceInt(
+            util.sample_distribution(
+                self.initial_state_dist,
+                random=self.rand_state,
+            )
         )
 
-    def transition(self, state: int, action: int) -> int:
+    def transition(
+        self, state: DiscreteSpaceInt, action: DiscreteSpaceInt
+    ) -> DiscreteSpaceInt:
         """Samples from transition distribution."""
-        return util.sample_distribution(
-            self.transition_matrix[state, action],
-            random=self.rand_state,
+        return DiscreteSpaceInt(
+            util.sample_distribution(
+                self.transition_matrix[state, action],
+                random=self.rand_state,
+            )
         )
 
-    def reward(self, state: int, action: int, new_state: int) -> float:
+    def reward(
+        self,
+        state: DiscreteSpaceInt,
+        action: DiscreteSpaceInt,
+        new_state: DiscreteSpaceInt,
+    ) -> float:
         """Computes reward for a given transition."""
         inputs = (state, action, new_state)[: len(self.reward_matrix.shape)]
         return self.reward_matrix[inputs]
 
-    def terminal(self, state: int, n_actions_taken: int) -> bool:
+    def terminal(self, state: DiscreteSpaceInt, n_actions_taken: int) -> bool:
         """Checks if state is terminal."""
+        del state
         return self.horizon is not None and n_actions_taken >= self.horizon
 
     @property
@@ -323,7 +310,7 @@ class BaseTabularModelPOMDP(ResettablePOMDP[int, Observation, int]):
         # Construct lazily to save memory in algorithms that don't need features.
         if self._feature_matrix is None:
             n_states = self.state_space.n
-            self._feature_matrix = np.eye(n_states)
+            self._feature_matrix = np.eye(int(n_states))
         return self._feature_matrix
 
     @property
@@ -337,7 +324,12 @@ class BaseTabularModelPOMDP(ResettablePOMDP[int, Observation, int]):
         return self.transition_matrix.shape[1]
 
 
-class TabularModelPOMDP(BaseTabularModelPOMDP[np.ndarray]):
+ObsEntryType = TypeVar(
+    "ObsEntryType", bound=np.floating[Any] | np.integer[Any], covariant=True
+)
+
+
+class TabularModelPOMDP(BaseTabularModelPOMDP[np.ndarray], Generic[ObsEntryType]):
     """Tabular model POMDP.
 
     This class is specifically for environments where observation != state,
@@ -349,13 +341,14 @@ class TabularModelPOMDP(BaseTabularModelPOMDP[np.ndarray]):
     a vector with self.obs_dim entries.
     """
 
-    observation_matrix: np.ndarray
+    observation_matrix: npt.NDArray[ObsEntryType]
+    observation_space: spaces.Box
 
     def __init__(
         self,
         *,
         transition_matrix: np.ndarray,
-        observation_matrix: np.ndarray,
+        observation_matrix: npt.NDArray[ObsEntryType],
         reward_matrix: np.ndarray,
         horizon: Optional[int] = None,
         initial_state_dist: Optional[np.ndarray] = None,
@@ -377,7 +370,6 @@ class TabularModelPOMDP(BaseTabularModelPOMDP[np.ndarray]):
                 f"observation_matrix.shape[0]: {observation_matrix.shape[0]}",
             )
 
-    def _construct_observation_space(self) -> gym.Space:
         min_val: float
         max_val: float
         try:
@@ -386,14 +378,14 @@ class TabularModelPOMDP(BaseTabularModelPOMDP[np.ndarray]):
         except ValueError:
             min_val = -np.inf
             max_val = np.inf
-        return spaces.Box(
+        self.observation_space = spaces.Box(
             low=min_val,
             high=max_val,
             shape=(self.obs_dim,),
             dtype=self.obs_dtype,
         )
 
-    def obs_from_state(self, state: int) -> np.ndarray:
+    def obs_from_state(self, state: DiscreteSpaceInt) -> npt.NDArray[ObsEntryType]:
         """Computes observation from state."""
         # Copy so it can't be mutated in-place (updates will be reflected in
         # self.observation_matrix!)
@@ -407,12 +399,12 @@ class TabularModelPOMDP(BaseTabularModelPOMDP[np.ndarray]):
         return self.observation_matrix.shape[1]
 
     @property
-    def obs_dtype(self) -> int:
+    def obs_dtype(self) -> np.dtype[ObsEntryType]:
         """Data type of observation vectors (e.g. np.float32)."""
         return self.observation_matrix.dtype
 
 
-class TabularModelMDP(BaseTabularModelPOMDP[int]):
+class TabularModelMDP(BaseTabularModelPOMDP[DiscreteSpaceInt]):
     """Tabular model MDP.
 
     A tabular model MDP is a tabular MDP where the transition and reward
@@ -444,9 +436,6 @@ class TabularModelMDP(BaseTabularModelPOMDP[int]):
             initial_state_dist=initial_state_dist,
         )
 
-    def obs_from_state(self, state: int) -> int:
+    def obs_from_state(self, state: DiscreteSpaceInt) -> DiscreteSpaceInt:
         """Identity since observation == state in an MDP."""
         return state
-
-    def _construct_observation_space(self) -> gym.Space:
-        return self._construct_state_space()

--- a/src/seals/base_envs.py
+++ b/src/seals/base_envs.py
@@ -84,7 +84,7 @@ class ResettablePOMDP(
     ) -> Tuple[ObsType, Dict[str, Any]]:
         """Reset the episode and return initial observation."""
         if options is not None:
-            raise ValueError("Options not supported.")
+            raise NotImplementedError("Options not supported.")
 
         super().reset(seed=seed)
         self.state = self.initial_state()
@@ -96,7 +96,7 @@ class ResettablePOMDP(
     def step(self, action: ActType) -> Tuple[ObsType, float, bool, bool, dict]:
         """Transition state using given action."""
         if self._cur_state is None or self._n_actions_taken is None:
-            raise ValueError("Need to call reset() before first step()")
+            raise RuntimeError("Need to call reset() before first step()")
         if action not in self.action_space:
             raise ValueError(f"{action} not in {self.action_space}")
 
@@ -117,7 +117,7 @@ class ResettablePOMDP(
         """Random state."""
         rand_state = self._np_random
         if rand_state is None:
-            raise ValueError("Need to call reset() before accessing rand_state")
+            raise RuntimeError("Need to call reset() before accessing rand_state")
         return rand_state
 
 

--- a/src/seals/base_envs.py
+++ b/src/seals/base_envs.py
@@ -5,14 +5,13 @@ from typing import Any, Dict, Generic, Optional, Tuple, TypeVar, Union
 
 import gymnasium as gym
 from gymnasium import spaces
+from gymnasium.core import ActType, ObsType
 import numpy as np
 import numpy.typing as npt
 
 from seals import util
 
 StateType = TypeVar("StateType")
-ObsType = TypeVar("ObsType")
-ActType = TypeVar("ActType")
 
 
 class ResettablePOMDP(
@@ -162,7 +161,7 @@ class ResettableMDP(
     """ABC for MDPs that are resettable."""
 
     @property
-    def observation_space(self) -> spaces.Space[StateType]:
+    def observation_space(self):
         """Observation space."""
         return self.state_space
 
@@ -333,7 +332,6 @@ class BaseTabularModelPOMDP(
 ObsEntryType = TypeVar(
     "ObsEntryType",
     bound=Union[np.floating, np.integer],
-    covariant=True,
 )
 
 
@@ -390,7 +388,7 @@ class TabularModelPOMDP(BaseTabularModelPOMDP[np.ndarray], Generic[ObsEntryType]
             low=min_val,
             high=max_val,
             shape=(self.obs_dim,),
-            dtype=self.obs_dtype,
+            dtype=self.obs_dtype,  # type: ignore
         )
 
     def obs_from_state(self, state: DiscreteSpaceInt) -> npt.NDArray[ObsEntryType]:

--- a/src/seals/base_envs.py
+++ b/src/seals/base_envs.py
@@ -5,13 +5,16 @@ from typing import Any, Dict, Generic, Optional, Tuple, TypeVar, Union
 
 import gymnasium as gym
 from gymnasium import spaces
-from gymnasium.core import ActType, ObsType
 import numpy as np
 import numpy.typing as npt
 
 from seals import util
 
+# Note: we redefine the type vars from gymnasium.core here, because pytype does not
+# recognize them as valid type vars if we import them from gymnasium.core.
 StateType = TypeVar("StateType")
+ActType = TypeVar("ActType")
+ObsType = TypeVar("ObsType")
 
 
 class ResettablePOMDP(

--- a/src/seals/base_envs.py
+++ b/src/seals/base_envs.py
@@ -115,13 +115,6 @@ class ResettablePOMDP(
         infos = {"old_state": old_state, "new_state": self._cur_state}
         return obs, reward, terminated, truncated, infos
 
-    @property
-    def rand_state(self) -> np.random.Generator:
-        """Random state."""
-        rand_state = self._np_random
-        if rand_state is None:
-            raise RuntimeError("Need to call reset() before accessing rand_state")
-        return rand_state
 
 
 class ExposePOMDPStateWrapper(
@@ -275,7 +268,7 @@ class BaseTabularModelPOMDP(
         return DiscreteSpaceInt(
             util.sample_distribution(
                 self.initial_state_dist,
-                random=self.rand_state,
+                random=self.np_random,
             ),
         )
 
@@ -288,7 +281,7 @@ class BaseTabularModelPOMDP(
         return DiscreteSpaceInt(
             util.sample_distribution(
                 self.transition_matrix[state, action],
-                random=self.rand_state,
+                random=self.np_random,
             ),
         )
 

--- a/src/seals/base_envs.py
+++ b/src/seals/base_envs.py
@@ -267,7 +267,7 @@ class BaseTabularModelPOMDP(
         return DiscreteSpaceInt(
             util.sample_distribution(
                 self.initial_state_dist,
-                random=self.rand_state,
+                random=self.np_random,
             ),
         )
 
@@ -280,7 +280,7 @@ class BaseTabularModelPOMDP(
         return DiscreteSpaceInt(
             util.sample_distribution(
                 self.transition_matrix[state, action],
-                random=self.rand_state,
+                random=self.np_random,
             ),
         )
 

--- a/src/seals/base_envs.py
+++ b/src/seals/base_envs.py
@@ -316,7 +316,7 @@ class BaseTabularModelPOMDP(
         # Construct lazily to save memory in algorithms that don't need features.
         if self._feature_matrix is None:
             n_states = self.state_space.n
-            self._feature_matrix = np.eye(int(n_states))
+            self._feature_matrix = np.eye(n_states)
         return self._feature_matrix
 
     @property

--- a/src/seals/base_envs.py
+++ b/src/seals/base_envs.py
@@ -71,7 +71,7 @@ class ResettablePOMDP(
 
     @state.setter
     def state(self, state: StateType):
-        """Set current state."""
+        """Set the current state."""
         if state not in self.state_space:
             raise ValueError(f"{state} not in {self.state_space}")
         self._cur_state = state
@@ -82,7 +82,7 @@ class ResettablePOMDP(
         seed: Optional[int] = None,
         options: Optional[Dict[str, Any]] = None,
     ) -> Tuple[ObsType, Dict[str, Any]]:
-        """Reset episode and return initial observation."""
+        """Reset the episode and return initial observation."""
         if options is not None:
             raise ValueError("Options not supported.")
 

--- a/src/seals/base_envs.py
+++ b/src/seals/base_envs.py
@@ -79,9 +79,9 @@ class ResettablePOMDP(
     def reset(
         self,
         *,
-        seed: Union[int, None] = None,
-        options: Union[Dict[str, Any], None]= None,
-    ) -> Tuple[ObsType, Dict[str, Any]]:  # type: ignore
+        seed: Optional[int] = None,
+        options: Optional[Dict[str, Any]] = None,
+    ) -> Tuple[ObsType, Dict[str, Any]]:
         """Reset episode and return initial observation."""
         if options is not None:
             raise ValueError("Options not supported.")
@@ -90,7 +90,7 @@ class ResettablePOMDP(
         self.state = self.initial_state()
         self._n_actions_taken = 0
         obs = self.obs_from_state(self.state)
-        info: dict[str, Any] = dict()
+        info: Dict[str, Any] = dict()
         return obs, info
 
     def step(self, action: ActType) -> Tuple[ObsType, float, bool, bool, dict]:
@@ -139,7 +139,7 @@ class ExposePOMDPStateWrapper(
         self._observation_space = env.state_space
 
     def reset(
-        self, seed: Union[int, None] = None, options: Union[Dict[str, Any], None]= None
+        self, seed: Optional[int] = None, options: Optional[Dict[str, Any]] = None
     ) -> Tuple[StateType, Dict[str, Any]]:
         """Reset environment and return initial state."""
         _, info = self.env.reset(seed=seed, options=options)
@@ -399,7 +399,7 @@ class TabularModelPOMDP(BaseTabularModelPOMDP[np.ndarray], Generic[ObsEntryType]
         return self.observation_matrix.shape[1]
 
     @property
-    def obs_dtype(self) -> np.dtype: 
+    def obs_dtype(self) -> np.dtype:
         """Data type of observation vectors (e.g. np.float32)."""
         return self.observation_matrix.dtype
 

--- a/src/seals/base_envs.py
+++ b/src/seals/base_envs.py
@@ -1,12 +1,12 @@
 """Base environment classes."""
 
 import abc
-from typing import Any, Generic, Optional, Tuple, TypeVar, Dict, Union
+from typing import Any, Dict, Generic, Optional, Tuple, TypeVar, Union
 
 import gymnasium as gym
+from gymnasium import spaces
 import numpy as np
 import numpy.typing as npt
-from gymnasium import spaces
 
 from seals import util
 

--- a/src/seals/base_envs.py
+++ b/src/seals/base_envs.py
@@ -435,6 +435,7 @@ class TabularModelMDP(BaseTabularModelPOMDP[DiscreteSpaceInt]):
             horizon=horizon,
             initial_state_dist=initial_state_dist,
         )
+        self.observation_space = self.state_space
 
     def obs_from_state(self, state: DiscreteSpaceInt) -> DiscreteSpaceInt:
         """Identity since observation == state in an MDP."""

--- a/src/seals/base_envs.py
+++ b/src/seals/base_envs.py
@@ -116,7 +116,6 @@ class ResettablePOMDP(
         return obs, reward, terminated, truncated, infos
 
 
-
 class ExposePOMDPStateWrapper(
     gym.Wrapper[StateType, ActType, ObsType, ActType],
     Generic[StateType, ObsType, ActType],
@@ -268,7 +267,7 @@ class BaseTabularModelPOMDP(
         return DiscreteSpaceInt(
             util.sample_distribution(
                 self.initial_state_dist,
-                random=self.np_random,
+                random=self.rand_state,
             ),
         )
 
@@ -281,7 +280,7 @@ class BaseTabularModelPOMDP(
         return DiscreteSpaceInt(
             util.sample_distribution(
                 self.transition_matrix[state, action],
-                random=self.np_random,
+                random=self.rand_state,
             ),
         )
 

--- a/src/seals/base_envs.py
+++ b/src/seals/base_envs.py
@@ -1,7 +1,7 @@
 """Base environment classes."""
 
 import abc
-from typing import Any, Generic, Optional, Tuple, TypeVar
+from typing import Any, Generic, Optional, Tuple, TypeVar, Dict, Union
 
 import gymnasium as gym
 import numpy as np
@@ -79,9 +79,9 @@ class ResettablePOMDP(
     def reset(
         self,
         *,
-        seed: int | None = None,
-        options: dict[str, Any] | None = None,
-    ) -> tuple[ObsType, dict[str, Any]]:  # type: ignore
+        seed: Union[int, None] = None,
+        options: Union[Dict[str, Any], None]= None,
+    ) -> Tuple[ObsType, Dict[str, Any]]:  # type: ignore
         """Reset episode and return initial observation."""
         if options is not None:
             raise ValueError("Options not supported.")
@@ -139,8 +139,8 @@ class ExposePOMDPStateWrapper(
         self._observation_space = env.state_space
 
     def reset(
-        self, seed: int | None = None, options: dict[str, Any] | None = None
-    ) -> Tuple[StateType, dict[str, Any]]:
+        self, seed: Union[int, None] = None, options: Union[Dict[str, Any], None]= None
+    ) -> Tuple[StateType, Dict[str, Any]]:
         """Reset environment and return initial state."""
         _, info = self.env.reset(seed=seed, options=options)
         return self.env.state, info
@@ -325,7 +325,7 @@ class BaseTabularModelPOMDP(
 
 
 ObsEntryType = TypeVar(
-    "ObsEntryType", bound=np.floating[Any] | np.integer[Any], covariant=True
+    "ObsEntryType", bound=Union[np.floating, np.integer], covariant=True
 )
 
 
@@ -399,7 +399,7 @@ class TabularModelPOMDP(BaseTabularModelPOMDP[np.ndarray], Generic[ObsEntryType]
         return self.observation_matrix.shape[1]
 
     @property
-    def obs_dtype(self) -> np.dtype[ObsEntryType]:
+    def obs_dtype(self) -> np.dtype: 
         """Data type of observation vectors (e.g. np.float32)."""
         return self.observation_matrix.dtype
 

--- a/src/seals/classic_control.py
+++ b/src/seals/classic_control.py
@@ -13,12 +13,12 @@ from seals import util
 class FixedHorizonCartPole(classic_control.CartPoleEnv):
     """Fixed-length variant of CartPole-v1.
 
-    Reward is 1.0 whenever the CartPole is an "ok" state (i.e. the pole is upright
-    and the cart is on the screen). Otherwise reward is 0.0.
-    
-    Terminated is always False. 
-    By default, this environment is wrapped in 'TimeLimit' with max steps 500
-    Truncation is handled by that.  
+    Reward is 1.0 whenever the CartPole is an "ok" state (i.e., the pole is upright
+    and the cart is on the screen). Otherwise, reward is 0.0.
+
+    Terminated is always False.
+    By default, this environment is wrapped in 'TimeLimit' with max steps 500,
+    Truncation is handled by that.
     """
 
     def __init__(self):

--- a/src/seals/classic_control.py
+++ b/src/seals/classic_control.py
@@ -2,12 +2,10 @@
 
 import warnings
 
-import numpy as np
-
 import gymnasium as gym
 from gymnasium import spaces
 from gymnasium.envs import classic_control
-
+import numpy as np
 
 from seals import util
 

--- a/src/seals/classic_control.py
+++ b/src/seals/classic_control.py
@@ -18,7 +18,7 @@ class FixedHorizonCartPole(classic_control.CartPoleEnv):
 
     Terminated is always False.
     By default, this environment is wrapped in 'TimeLimit' with max steps 500,
-    Truncation is handled by that.
+    which sets `truncated` to true after that many steps.
     """
 
     def __init__(self):

--- a/src/seals/classic_control.py
+++ b/src/seals/classic_control.py
@@ -23,9 +23,9 @@ class FixedHorizonCartPole(classic_control.CartPoleEnv):
     which sets `truncated` to true after that many steps.
     """
 
-    def __init__(self):
+    def __init__(self, *args, **kwargs):
         """Builds FixedHorizonCartPole, modifying observation_space from gym parent."""
-        super().__init__()
+        super().__init__(*args, **kwargs)
 
         high = [
             np.finfo(np.float32).max,  # x axis
@@ -64,7 +64,7 @@ class FixedHorizonCartPole(classic_control.CartPoleEnv):
         return np.array(self.state, dtype=np.float32), rew, False, False, {}
 
 
-def mountain_car():
+def mountain_car(*args, **kwargs):
     """Fixed-length variant of MountainCar-v0.
 
     In the event of early episode completion (i.e., the car reaches the
@@ -73,7 +73,7 @@ def mountain_car():
 
     Done is always returned on timestep 200 only.
     """
-    env = gym.make("MountainCar-v0")
+    env = gym.make("MountainCar-v0", *args, **kwargs)
     env = util.ObsCastWrapper(env, dtype=np.float32)
     env = util.AbsorbAfterDoneWrapper(env)
     return env

--- a/src/seals/classic_control.py
+++ b/src/seals/classic_control.py
@@ -15,9 +15,10 @@ class FixedHorizonCartPole(classic_control.CartPoleEnv):
 
     Reward is 1.0 whenever the CartPole is an "ok" state (i.e. the pole is upright
     and the cart is on the screen). Otherwise reward is 0.0.
-
-    Done is always False. (Though note that by default, this environment is wrapped
-    in `TimeLimit` with max steps 500.)
+    
+    Terminated is always False. 
+    By default, this environment is wrapped in 'TimeLimit' with max steps 500
+    Truncation is handled by that.  
     """
 
     def __init__(self):
@@ -33,9 +34,10 @@ class FixedHorizonCartPole(classic_control.CartPoleEnv):
         high = np.array(high)
         self.observation_space = spaces.Box(-high, high, dtype=np.float32)
 
-    def reset(self):
+    def reset(self, seed=None, options={}):
         """Reset for FixedHorizonCartPole."""
-        return super().reset().astype(np.float32)
+        observation, info = super().reset(seed=seed, options=options)
+        return observation.astype(np.float32), info
 
     def step(self, action):
         """Step function for FixedHorizonCartPole."""
@@ -56,7 +58,7 @@ class FixedHorizonCartPole(classic_control.CartPoleEnv):
         )
 
         rew = 1.0 if state_ok else 0.0
-        return np.array(self.state, dtype=np.float32), rew, False, {}
+        return np.array(self.state, dtype=np.float32), rew, False, False, {}
 
 
 def mountain_car():

--- a/src/seals/classic_control.py
+++ b/src/seals/classic_control.py
@@ -1,5 +1,6 @@
 """Adaptation of classic Gym environments for specification learning algorithms."""
 
+from typing import Any, Dict, Optional
 import warnings
 
 import gymnasium as gym
@@ -34,7 +35,11 @@ class FixedHorizonCartPole(classic_control.CartPoleEnv):
         high = np.array(high)
         self.observation_space = spaces.Box(-high, high, dtype=np.float32)
 
-    def reset(self, seed=None, options={}):
+    def reset(
+        self,
+        seed: Optional[int] = None,
+        options: Optional[Dict[str, Any]] = None,
+    ):
         """Reset for FixedHorizonCartPole."""
         observation, info = super().reset(seed=seed, options=options)
         return observation.astype(np.float32), info

--- a/src/seals/classic_control.py
+++ b/src/seals/classic_control.py
@@ -42,7 +42,8 @@ class FixedHorizonCartPole(classic_control.CartPoleEnv):
     def step(self, action):
         """Step function for FixedHorizonCartPole."""
         with warnings.catch_warnings():
-            # Filter out CartPoleEnv warning for calling step() beyond done=True.
+            # Filter out CartPoleEnv warning for calling step() beyond
+            # terminated=True or truncated=True
             warnings.filterwarnings("ignore", ".*You are calling.*")
             super().step(action)
 

--- a/src/seals/classic_control.py
+++ b/src/seals/classic_control.py
@@ -3,6 +3,8 @@
 import warnings
 
 import numpy as np
+
+import gymnasium as gym
 from gymnasium import spaces
 from gymnasium.envs import classic_control
 
@@ -71,7 +73,7 @@ def mountain_car():
 
     Done is always returned on timestep 200 only.
     """
-    env = util.make_env_no_wrappers("MountainCar-v0")
+    env = gym.make("MountainCar-v0")
     env = util.ObsCastWrapper(env, dtype=np.float32)
     env = util.AbsorbAfterDoneWrapper(env)
     return env

--- a/src/seals/classic_control.py
+++ b/src/seals/classic_control.py
@@ -2,14 +2,15 @@
 
 import warnings
 
-from gym import spaces
-import gym.envs.classic_control
 import numpy as np
+from gymnasium import spaces
+from gymnasium.envs import classic_control
+
 
 from seals import util
 
 
-class FixedHorizonCartPole(gym.envs.classic_control.CartPoleEnv):
+class FixedHorizonCartPole(classic_control.CartPoleEnv):
     """Fixed-length variant of CartPole-v1.
 
     Reward is 1.0 whenever the CartPole is an "ok" state (i.e. the pole is upright
@@ -20,7 +21,7 @@ class FixedHorizonCartPole(gym.envs.classic_control.CartPoleEnv):
     """
 
     def __init__(self):
-        """Builds FixedHorizonCartPole, modifying observation_space from Gym parent."""
+        """Builds FixedHorizonCartPole, modifying observation_space from gym parent."""
         super().__init__()
 
         high = [

--- a/src/seals/diagnostics/__init__.py
+++ b/src/seals/diagnostics/__init__.py
@@ -1,6 +1,6 @@
 """Simple diagnostic environments."""
 
-import gym
+import gymnasium as gym
 
 gym.register(
     id="seals/Branching-v0",

--- a/src/seals/diagnostics/early_term.py
+++ b/src/seals/diagnostics/early_term.py
@@ -53,7 +53,7 @@ class EarlyTerminationEnv(base_envs.TabularModelMDP):
             reward_matrix=reward_matrix,
         )
 
-    def terminal(self, state: int, n_actions_taken: int) -> bool:
+    def terminal(self, state: base_envs.DiscreteSpaceInt, n_actions_taken: int) -> bool:
         """Returns True if (and only if) in state 2."""
         return bool(state == 2)
 

--- a/src/seals/diagnostics/init_shift.py
+++ b/src/seals/diagnostics/init_shift.py
@@ -27,7 +27,7 @@ class InitShiftEnv(base_envs.TabularModelMDP):
     disambiguate this case.
     """
 
-    def __init__(self, initial_state: int):
+    def __init__(self, initial_state: base_envs.DiscreteSpaceInt):
         """Constructs environment.
 
         Args:
@@ -63,7 +63,7 @@ class InitShiftEnv(base_envs.TabularModelMDP):
             reward_matrix=reward_matrix,
         )
 
-    def initial_state(self) -> int:
+    def initial_state(self) -> base_envs.DiscreteSpaceInt:
         """Returns initial state defined in constructor."""
         return self._initial_state
 

--- a/src/seals/diagnostics/largest_sum.py
+++ b/src/seals/diagnostics/largest_sum.py
@@ -1,7 +1,7 @@
 """Environment testing scalability to high-dimensional tasks."""
 
-import numpy as np
 from gymnasium import spaces
+import numpy as np
 
 from seals import base_envs
 

--- a/src/seals/diagnostics/largest_sum.py
+++ b/src/seals/diagnostics/largest_sum.py
@@ -34,7 +34,7 @@ class LargestSumEnv(base_envs.ResettableMDP):
 
     def initial_state(self) -> np.ndarray:
         """Returns vector sampled uniformly in [0, 1]**L."""
-        init_state = self.rand_state.random((self._length,))
+        init_state = self.np_random.random((self._length,))
         return init_state.astype(self.observation_space.dtype)
 
     def reward(self, state: np.ndarray, act: int, next_state: np.ndarray) -> float:

--- a/src/seals/diagnostics/largest_sum.py
+++ b/src/seals/diagnostics/largest_sum.py
@@ -1,7 +1,7 @@
 """Environment testing scalability to high-dimensional tasks."""
 
-from gym import spaces
 import numpy as np
+from gymnasium import spaces
 
 from seals import base_envs
 
@@ -23,12 +23,10 @@ class LargestSumEnv(base_envs.ResettableMDP):
         Args:
             length: dimensionality of state space vector.
         """
+        super().__init__()
         self._length = length
-        state_space = spaces.Box(low=0.0, high=1.0, shape=(length,))
-        super().__init__(
-            state_space=state_space,
-            action_space=spaces.Discrete(2),
-        )
+        self.state_space = spaces.Box(low=0.0, high=1.0, shape=(length,))
+        self.action_space = spaces.Discrete(2)
 
     def terminal(self, state: np.ndarray, n_actions_taken: int) -> bool:
         """Always returns True, since this task should have a 1-timestep horizon."""
@@ -36,7 +34,7 @@ class LargestSumEnv(base_envs.ResettableMDP):
 
     def initial_state(self) -> np.ndarray:
         """Returns vector sampled uniformly in [0, 1]**L."""
-        init_state = self.rand_state.rand(self._length)
+        init_state = self.rand_state.random((self._length,))
         return init_state.astype(self.observation_space.dtype)
 
     def reward(self, state: np.ndarray, act: int, next_state: np.ndarray) -> float:

--- a/src/seals/diagnostics/noisy_obs.py
+++ b/src/seals/diagnostics/noisy_obs.py
@@ -1,7 +1,7 @@
 """Environment testing for robustness to noise."""
 
-import numpy as np
 from gymnasium import spaces
+import numpy as np
 
 from seals import base_envs, util
 

--- a/src/seals/diagnostics/noisy_obs.py
+++ b/src/seals/diagnostics/noisy_obs.py
@@ -1,7 +1,7 @@
 """Environment testing for robustness to noise."""
 
-from gym import spaces
 import numpy as np
+from gymnasium import spaces
 
 from seals import base_envs, util
 
@@ -23,6 +23,8 @@ class NoisyObsEnv(base_envs.ResettablePOMDP):
             size: width and height of gridworld.
             noise_length: dimension of noise vector in observation.
         """
+        super().__init__()
+
         self._size = size
         self._noise_length = noise_length
         self._goal = np.array([self._size // 2, self._size // 2])
@@ -34,14 +36,12 @@ class NoisyObsEnv(base_envs.ResettablePOMDP):
             ([size - 1, size - 1], np.full(self._noise_length, np.inf)),  # type: ignore
         )
 
-        super().__init__(
-            state_space=spaces.MultiDiscrete([size, size]),
-            action_space=spaces.Discrete(5),
-            observation_space=spaces.Box(
-                low=obs_box_low,
-                high=obs_box_high,
-                dtype=np.float32,
-            ),
+        self.state_space = spaces.MultiDiscrete([size, size])
+        self.action_space = spaces.Discrete(5)
+        self.observation_space = spaces.Box(
+            low=obs_box_low,
+            high=obs_box_high,
+            dtype=np.float32,
         )
 
     def terminal(self, state: np.ndarray, n_actions_taken: int) -> bool:
@@ -52,7 +52,7 @@ class NoisyObsEnv(base_envs.ResettablePOMDP):
         """Returns one of the grid's corners."""
         n = self._size
         corners = np.array([[0, 0], [n - 1, 0], [0, n - 1], [n - 1, n - 1]])
-        return corners[self.rand_state.randint(4)]
+        return corners[self.rand_state.integers(4)]
 
     def reward(self, state: np.ndarray, action: int, new_state: np.ndarray) -> float:
         """Returns  +1.0 reward if state is the goal and 0.0 otherwise."""

--- a/src/seals/diagnostics/noisy_obs.py
+++ b/src/seals/diagnostics/noisy_obs.py
@@ -69,5 +69,5 @@ class NoisyObsEnv(base_envs.ResettablePOMDP):
 
     def obs_from_state(self, state: np.ndarray) -> np.ndarray:
         """Returns (x, y) concatenated with Gaussian noise."""
-        noise_vector = self.rand_state.randn(self._noise_length)
+        noise_vector = self.rand_state.normal(size=self._noise_length)
         return np.concatenate([state, noise_vector]).astype(np.float32)

--- a/src/seals/diagnostics/noisy_obs.py
+++ b/src/seals/diagnostics/noisy_obs.py
@@ -52,7 +52,7 @@ class NoisyObsEnv(base_envs.ResettablePOMDP):
         """Returns one of the grid's corners."""
         n = self._size
         corners = np.array([[0, 0], [n - 1, 0], [0, n - 1], [n - 1, n - 1]])
-        return corners[self.rand_state.integers(4)]
+        return corners[self.np_random.integers(4)]
 
     def reward(self, state: np.ndarray, action: int, new_state: np.ndarray) -> float:
         """Returns  +1.0 reward if state is the goal and 0.0 otherwise."""
@@ -69,5 +69,5 @@ class NoisyObsEnv(base_envs.ResettablePOMDP):
 
     def obs_from_state(self, state: np.ndarray) -> np.ndarray:
         """Returns (x, y) concatenated with Gaussian noise."""
-        noise_vector = self.rand_state.normal(size=self._noise_length)
+        noise_vector = self.np_random.normal(size=self._noise_length)
         return np.concatenate([state, noise_vector]).astype(np.float32)

--- a/src/seals/diagnostics/parabola.py
+++ b/src/seals/diagnostics/parabola.py
@@ -40,7 +40,7 @@ class ParabolaEnv(base_envs.ResettableMDP):
 
     def initial_state(self) -> np.ndarray:
         """Get state by sampling a random parabola."""
-        a, b, c = -1 + 2 * self.rand_state.random((3,))
+        a, b, c = -1 + 2 * self.np_random.random((3,))
         x, y = 0, c
         return np.array([x, y, a, b, c], dtype=self.state_space.dtype)
 

--- a/src/seals/diagnostics/parabola.py
+++ b/src/seals/diagnostics/parabola.py
@@ -1,7 +1,7 @@
 """Environment testing for generalization in continuous spaces."""
 
-from gym import spaces
 import numpy as np
+from gymnasium import spaces
 
 from seals import base_envs
 
@@ -24,16 +24,15 @@ class ParabolaEnv(base_envs.ResettableMDP):
             bounds: limits coordinates, useful for keeping rewards in
                 a small bounded range.
         """
+        super().__init__()
         self._x_step = x_step
         self._bounds = bounds
 
         state_high = np.array([bounds, bounds, 1.0, 1.0, 1.0])
         state_low = (-1) * state_high
 
-        super().__init__(
-            state_space=spaces.Box(low=state_low, high=state_high),
-            action_space=spaces.Box(low=(-2) * bounds, high=2 * bounds, shape=()),
-        )
+        self.state_space = spaces.Box(low=state_low, high=state_high)
+        self.action_space = spaces.Box(low=(-2) * bounds, high=2 * bounds, shape=())
 
     def terminal(self, state: int, n_actions_taken: int) -> bool:
         """Always returns False."""
@@ -41,7 +40,7 @@ class ParabolaEnv(base_envs.ResettableMDP):
 
     def initial_state(self) -> np.ndarray:
         """Get state by sampling a random parabola."""
-        a, b, c = -1 + 2 * self.rand_state.rand(3)
+        a, b, c = -1 + 2 * self.rand_state.random((3,))
         x, y = 0, c
         return np.array([x, y, a, b, c], dtype=self.state_space.dtype)
 

--- a/src/seals/diagnostics/parabola.py
+++ b/src/seals/diagnostics/parabola.py
@@ -1,7 +1,7 @@
 """Environment testing for generalization in continuous spaces."""
 
-import numpy as np
 from gymnasium import spaces
+import numpy as np
 
 from seals import base_envs
 

--- a/src/seals/diagnostics/proc_goal.py
+++ b/src/seals/diagnostics/proc_goal.py
@@ -1,7 +1,7 @@
 """Large gridworld with random agent and goal position."""
 
-import numpy as np
 from gymnasium import spaces
+import numpy as np
 
 from seals import base_envs, util
 

--- a/src/seals/diagnostics/proc_goal.py
+++ b/src/seals/diagnostics/proc_goal.py
@@ -40,11 +40,11 @@ class ProcGoalEnv(base_envs.ResettableMDP):
 
     def initial_state(self) -> np.ndarray:
         """Samples random agent position and random goal."""
-        pos = self.rand_state.integers(low=-self._bounds, high=self._bounds, size=(2,))
+        pos = self.np_random.integers(low=-self._bounds, high=self._bounds, size=(2,))
 
-        x_dist = self.rand_state.integers(self._distance)
+        x_dist = self.np_random.integers(self._distance)
         y_dist = self._distance - x_dist
-        random_signs = 2 * self.rand_state.integers(2, size=2) - 1
+        random_signs = 2 * self.np_random.integers(2, size=2) - 1
         goal = pos + random_signs * (x_dist, y_dist)
 
         return np.concatenate([pos, goal]).astype(self.observation_space.dtype)

--- a/src/seals/diagnostics/proc_goal.py
+++ b/src/seals/diagnostics/proc_goal.py
@@ -1,7 +1,7 @@
 """Large gridworld with random agent and goal position."""
 
-from gym import spaces
 import numpy as np
+from gymnasium import spaces
 
 from seals import base_envs, util
 
@@ -28,13 +28,11 @@ class ProcGoalEnv(base_envs.ResettableMDP):
                 generalization harder.
             distance: initial distance between agent and goal.
         """
+        super().__init__()
         self._bounds = bounds
         self._distance = distance
-
-        super().__init__(
-            state_space=spaces.Box(low=-np.inf, high=np.inf, shape=(4,)),
-            action_space=spaces.Discrete(5),
-        )
+        self.state_space = spaces.Box(low=-np.inf, high=np.inf, shape=(4,))
+        self.action_space = spaces.Discrete(5)
 
     def terminal(self, state: np.ndarray, n_actions_taken: int) -> bool:
         """Always returns False."""
@@ -42,11 +40,11 @@ class ProcGoalEnv(base_envs.ResettableMDP):
 
     def initial_state(self) -> np.ndarray:
         """Samples random agent position and random goal."""
-        pos = self.rand_state.randint(low=-self._bounds, high=self._bounds, size=(2,))
+        pos = self.rand_state.integers(low=-self._bounds, high=self._bounds, size=(2,))
 
-        x_dist = self.rand_state.randint(self._distance)
+        x_dist = self.rand_state.integers(self._distance)
         y_dist = self._distance - x_dist
-        random_signs = 2 * self.rand_state.randint(2, size=2) - 1
+        random_signs = 2 * self.rand_state.integers(2, size=2) - 1
         goal = pos + random_signs * (x_dist, y_dist)
 
         return np.concatenate([pos, goal]).astype(self.observation_space.dtype)

--- a/src/seals/diagnostics/random_trans.py
+++ b/src/seals/diagnostics/random_trans.py
@@ -72,7 +72,7 @@ class RandomTransitionEnv(TabularModelPOMDP):
             n_states=n_states,
             rand_state=rand_gen,
         )
-        
+
         self.reward_weights = rand_gen.normal(
             0, 1, size=(observation_matrix.shape[-1],),
         )

--- a/src/seals/diagnostics/random_trans.py
+++ b/src/seals/diagnostics/random_trans.py
@@ -73,11 +73,7 @@ class RandomTransitionEnv(TabularModelPOMDP):
             rand_state=rand_gen,
         )
 
-        self.reward_weights = rand_gen.normal(
-            0,
-            1,
-            size=(observation_matrix.shape[-1],),
-        )
+        self.reward_weights = rand_gen.normal(size=(observation_matrix.shape[-1],))
         reward_matrix = observation_matrix @ self.reward_weights
         super().__init__(
             transition_matrix=transition_matrix,

--- a/src/seals/diagnostics/random_trans.py
+++ b/src/seals/diagnostics/random_trans.py
@@ -46,7 +46,7 @@ class RandomTransitionEnv(TabularModelPOMDP):
         """
         # this generator is ONLY for constructing the MDP, not for controlling
         # random outcomes during rollouts
-        rand_gen = np.random.RandomState(generator_seed)
+        rand_gen = np.random.default_rng(generator_seed)
 
         if random_obs:
             if obs_dim is None:
@@ -87,7 +87,7 @@ class RandomTransitionEnv(TabularModelPOMDP):
         n_states,
         n_actions,
         max_branch_factor,
-        rand_state: Optional[np.random.RandomState] = None,
+        rand_state: Optional[np.random.Generator] = None,
     ) -> np.ndarray:
         """Make a 'random' transition matrix.
 
@@ -110,14 +110,14 @@ class RandomTransitionEnv(TabularModelPOMDP):
             of transitioning to `next_s` after taking action `a` in state `s`.
         """
         if rand_state is None:
-            rand_state = np.random.RandomState()
+            rand_state = np.random.default_rng()
         assert rand_state is not None
         out_mat = np.zeros((n_states, n_actions, n_states), dtype="float32")
         for start_state in range(n_states):
             for action in range(n_actions):
                 # uniformly sample a number of successors in [1,max_branch_factor]
                 # for this action
-                successors = rand_state.randint(1, max_branch_factor + 1)
+                successors = rand_state.integers(1, max_branch_factor + 1)
                 next_states = rand_state.choice(
                     n_states,
                     size=(successors,),
@@ -133,7 +133,7 @@ class RandomTransitionEnv(TabularModelPOMDP):
     def make_random_state_dist(
         n_avail: int,
         n_states: int,
-        rand_state: Optional[np.random.RandomState] = None,
+        rand_state: Optional[np.random.Generator] = None,
     ) -> np.ndarray:
         """Make a random initial state distribution over n_states.
 
@@ -152,7 +152,7 @@ class RandomTransitionEnv(TabularModelPOMDP):
             ValueError: If `n_avail` is not in the range `(0, n_states]`.
         """  # noqa: DAR402
         if rand_state is None:
-            rand_state = np.random.RandomState()
+            rand_state = np.random.default_rng()
         assert rand_state is not None
         assert 0 < n_avail <= n_states
         init_dist = np.zeros((n_states,))
@@ -168,7 +168,7 @@ class RandomTransitionEnv(TabularModelPOMDP):
         n_states: int,
         is_random: bool,
         obs_dim: Optional[int] = None,
-        rand_state: Optional[np.random.RandomState] = None,
+        rand_state: Optional[np.random.Generator] = None,
     ) -> np.ndarray:
         """Makes an observation matrix with a single observation for each state.
 
@@ -179,7 +179,7 @@ class RandomTransitionEnv(TabularModelPOMDP):
                         If `False`, are unique one-hot vectors for each state.
             obs_dim (int or NoneType): Must be `None` if `is_random == False`.
                     Otherwise, this must be set to the size of the random vectors.
-            rand_state (np.random.RandomState): Random number generator.
+            rand_state (np.random.Generator): Random number generator.
 
         Returns:
             A matrix of shape `(n_states, obs_dim if is_random else n_states)`.
@@ -188,7 +188,7 @@ class RandomTransitionEnv(TabularModelPOMDP):
             ValueError: If ``is_random == False`` and ``obs_dim is not None``.
         """
         if rand_state is None:
-            rand_state = np.random.RandomState()
+            rand_state = np.random.default_rng()
         assert rand_state is not None
         if is_random:
             if obs_dim is None:

--- a/src/seals/diagnostics/random_trans.py
+++ b/src/seals/diagnostics/random_trans.py
@@ -72,7 +72,10 @@ class RandomTransitionEnv(TabularModelPOMDP):
             n_states=n_states,
             rand_state=rand_gen,
         )
-        self.reward_weights = rand_gen.randn(observation_matrix.shape[-1])
+        
+        self.reward_weights = rand_gen.normal(
+            0, 1, size=(observation_matrix.shape[-1],)
+        )
         reward_matrix = observation_matrix @ self.reward_weights
         super().__init__(
             transition_matrix=transition_matrix,

--- a/src/seals/diagnostics/random_trans.py
+++ b/src/seals/diagnostics/random_trans.py
@@ -74,7 +74,7 @@ class RandomTransitionEnv(TabularModelPOMDP):
         )
         
         self.reward_weights = rand_gen.normal(
-            0, 1, size=(observation_matrix.shape[-1],)
+            0, 1, size=(observation_matrix.shape[-1],),
         )
         reward_matrix = observation_matrix @ self.reward_weights
         super().__init__(

--- a/src/seals/diagnostics/random_trans.py
+++ b/src/seals/diagnostics/random_trans.py
@@ -74,7 +74,9 @@ class RandomTransitionEnv(TabularModelPOMDP):
         )
 
         self.reward_weights = rand_gen.normal(
-            0, 1, size=(observation_matrix.shape[-1],),
+            0,
+            1,
+            size=(observation_matrix.shape[-1],),
         )
         reward_matrix = observation_matrix @ self.reward_weights
         super().__init__(

--- a/src/seals/diagnostics/sort.py
+++ b/src/seals/diagnostics/sort.py
@@ -1,7 +1,7 @@
 """Environment to sort a list using swap actions."""
 
-from gym import spaces
 import numpy as np
+from gymnasium import spaces
 
 from seals import base_envs
 
@@ -21,10 +21,9 @@ class SortEnv(base_envs.ResettableMDP):
         """
         self._length = length
 
-        super().__init__(
-            state_space=spaces.Box(low=0, high=1.0, shape=(length,)),
-            action_space=spaces.MultiDiscrete([length, length]),
-        )
+        super().__init__()
+        self.state_space = spaces.Box(low=0, high=1.0, shape=(length,))
+        self.action_space = spaces.MultiDiscrete([length, length])
 
     def terminal(self, state: np.ndarray, n_actions_taken: int) -> bool:
         """Always returns False."""
@@ -42,6 +41,7 @@ class SortEnv(base_envs.ResettableMDP):
         new_state: np.ndarray,
     ) -> float:
         """Rewards fully sorted lists, and new correct positions."""
+        del action
         # This is not meant to be a potential shaping in the formal sense,
         # as it changes the trajectory returns (since we do not return
         # a fixed-potential state at termination).

--- a/src/seals/diagnostics/sort.py
+++ b/src/seals/diagnostics/sort.py
@@ -1,7 +1,7 @@
 """Environment to sort a list using swap actions."""
 
-import numpy as np
 from gymnasium import spaces
+import numpy as np
 
 from seals import base_envs
 

--- a/src/seals/diagnostics/sort.py
+++ b/src/seals/diagnostics/sort.py
@@ -31,7 +31,7 @@ class SortEnv(base_envs.ResettableMDP):
 
     def initial_state(self):
         """Sample random vector uniformly in [0, 1]**L."""
-        sample = self.rand_state.random(size=self._length)
+        sample = self.np_random.random(size=self._length)
         return sample.astype(self.state_space.dtype)
 
     def reward(

--- a/src/seals/mujoco.py
+++ b/src/seals/mujoco.py
@@ -3,12 +3,12 @@
 import functools
 
 from gymnasium.envs.mujoco import (
-    ant_v3,
-    half_cheetah_v3,
-    hopper_v3,
-    humanoid_v3,
-    swimmer_v3,
-    walker2d_v3,
+    ant_v4,
+    half_cheetah_v4,
+    hopper_v4,
+    humanoid_v4,
+    swimmer_v4,
+    walker2d_v4,
 )
 
 
@@ -27,33 +27,33 @@ def _no_early_termination(cls):
 
 @_include_position_in_observation
 @_no_early_termination
-class AntEnv(ant_v3.AntEnv):
+class AntEnv(ant_v4.AntEnv):
     """Ant with position observation and no early termination."""
 
 
 @_include_position_in_observation
-class HalfCheetahEnv(half_cheetah_v3.HalfCheetahEnv):
+class HalfCheetahEnv(half_cheetah_v4.HalfCheetahEnv):
     """HalfCheetah with position observation. Naturally does not terminate early."""
 
 
 @_include_position_in_observation
 @_no_early_termination
-class HopperEnv(hopper_v3.HopperEnv):
+class HopperEnv(hopper_v4.HopperEnv):
     """Hopper with position observation and no early termination."""
 
 
 @_include_position_in_observation
 @_no_early_termination
-class HumanoidEnv(humanoid_v3.HumanoidEnv):
+class HumanoidEnv(humanoid_v4.HumanoidEnv):
     """Humanoid with position observation and no early termination."""
 
 
 @_include_position_in_observation
-class SwimmerEnv(swimmer_v3.SwimmerEnv):
+class SwimmerEnv(swimmer_v4.SwimmerEnv):
     """Swimmer with position observation. Naturally does not terminate early."""
 
 
 @_include_position_in_observation
 @_no_early_termination
-class Walker2dEnv(walker2d_v3.Walker2dEnv):
+class Walker2dEnv(walker2d_v4.Walker2dEnv):
     """Walker2d with position observation and no early termination."""

--- a/src/seals/mujoco.py
+++ b/src/seals/mujoco.py
@@ -2,7 +2,7 @@
 
 import functools
 
-from gym.envs.mujoco import (
+from gymnasium.envs.mujoco import (
     ant_v3,
     half_cheetah_v3,
     hopper_v3,

--- a/src/seals/testing/envs.py
+++ b/src/seals/testing/envs.py
@@ -95,9 +95,10 @@ def get_rollout(env: gym.Env, actions: Iterable[Any]) -> Rollout:
       actions: the actions to perform.
 
     Returns:
-      A sequence of 4-tuples (obs, rew, terminated, truncated, info).
+      A sequence of 5-tuples (obs, rew, terminated, truncated, info).
     """
-    ret: List[Step] = [(env.reset(), None, False, False, {})]
+    obs, info = env.reset()
+    ret: List[Step] = [(obs, None, False, False, {})]
     for act in actions:
         ret.append(env.step(act))
     return ret
@@ -338,10 +339,10 @@ class CountingEnv(gym.Env):
         self.episode_length = episode_length
         self.timestep = None
 
-    def reset(self):
+    def reset(self, seed=None, options={}):
         """Reset method for CountingEnv."""
         t, self.timestep = 0, 1
-        return np.array(t, dtype=self.observation_space.dtype)
+        return np.array(t, dtype=self.observation_space.dtype), {}
 
     def step(self, action):
         """Step method for CountingEnv."""

--- a/src/seals/testing/envs.py
+++ b/src/seals/testing/envs.py
@@ -12,15 +12,15 @@ from typing import (
     Iterator,
     List,
     Mapping,
-    Optional,
     Sequence,
+    SupportsFloat,
     Tuple,
 )
 
 import gymnasium as gym
 import numpy as np
 
-Step = Tuple[Any, Optional[float], bool, bool, Mapping[str, Any]]
+Step = Tuple[Any, SupportsFloat, bool, bool, Mapping[str, Any]]
 Rollout = Sequence[Step]
 """A sequence of 5-tuples (obs, rew, terminated, truncated, info) as returned by
 `get_rollout`."""
@@ -99,7 +99,7 @@ def get_rollout(env: gym.Env, actions: Iterable[Any]) -> Rollout:
       A sequence of 5-tuples (obs, rew, terminated, truncated, info).
     """
     obs, info = env.reset()
-    ret: List[Step] = [(obs, None, False, False, {})]
+    ret: List[Step] = [(obs, 0, False, False, {})]
     for act in actions:
         ret.append(env.step(act))
     return ret
@@ -192,7 +192,7 @@ def _check_obs(obs: np.ndarray, obs_space: gym.Space) -> None:
     assert obs in obs_space
 
 
-def _sample_and_check(env: gym.Env, obs_space: gym.Space) -> Tuple[bool, bool]:
+def _sample_and_check(env: gym.Env, obs_space: gym.Space) -> bool:
     """Sample from env and check return value is of valid type."""
     act = env.action_space.sample()
     obs, rew, terminated, truncated, info = env.step(act)

--- a/src/seals/testing/envs.py
+++ b/src/seals/testing/envs.py
@@ -203,7 +203,7 @@ def _sample_and_check(env: gym.Env, obs_space: gym.Space) -> Tuple[bool, bool]:
     return terminated or truncated
 
 
-def _is_mujoco_env(env: gym.Env) -> bool:
+def is_mujoco_env(env: gym.Env) -> bool:
     return hasattr(env, "sim") and hasattr(env, "model")
 
 
@@ -258,7 +258,7 @@ def test_premature_step(env: gym.Env, skip_fn, raises_fn) -> None:
     Raises:
         AssertionError if test fails.
     """
-    if _is_mujoco_env(env):  # pragma: no cover
+    if is_mujoco_env(env):  # pragma: no cover
         # We can't use isinstance since importing mujoco_py will fail on
         # machines without MuJoCo installed
         skip_fn("MuJoCo environments cannot perform this check.")
@@ -266,49 +266,6 @@ def test_premature_step(env: gym.Env, skip_fn, raises_fn) -> None:
     act = env.action_space.sample()
     with raises_fn(Exception):  # need to call env.reset() first
         env.step(act)
-
-
-def test_render(env: gym.Env, raises_fn) -> None:
-    """Test that render() supports the modes declared.
-
-    Example usage in pytest:
-        test_render(env, raises_fn=pytest.raises)
-
-    Args:
-        env: The environment to test.
-        raises_fn: Context manager to check NotImplementedError is thrown when
-            environment metadata indicates modes are supported.
-
-    Raises:
-        AssertionError: if test fails. This occurs if:
-            (a) `env.render(mode=mode)` fails for any mode declared supported
-            in `env.metadata["render.modes"]`; (b) env.render() *succeeds* when
-            `env.metadata["render.modes"]` is empty; (c) `env.render(mode="rgb_array")`
-            returns different values at the same time step.
-    """
-    env.reset(seed=0)  # make sure environment is in consistent state
-
-    render_modes = env.metadata["render_modes"]
-    if not render_modes:
-        # No modes supported -- render() should fail.
-        with raises_fn(NotImplementedError):
-            env.render()
-    else:
-        for mode in render_modes:
-            env.render(mode=mode)
-
-        # WARNING(adam): there seems to be a memory leak with Gym 0.17.3
-        # & MuJoCoPy 1.50.1.68. `MujocoEnv.close()` does not call `finish()`
-        # on the viewer (commented out) so the resources are not released.
-        # For now this is OK, but may bite if we end up testing a lot of
-        # MuJoCo environments.
-        is_mujoco = _is_mujoco_env(env)
-        if "rgb_array" in render_modes and not is_mujoco:
-            # Render should not change without calling `step()`.
-            # MuJoCo rendering fails this check, ignore -- not much we can do.
-            resa = env.render(mode="rgb_array")
-            resb = env.render(mode="rgb_array")
-            assert np.allclose(resa, resb)
 
 
 class CountingEnv(gym.Env):

--- a/src/seals/testing/envs.py
+++ b/src/seals/testing/envs.py
@@ -89,10 +89,10 @@ def matches_list(env_name: str, patterns: Iterable[str]) -> bool:
 
 
 def get_rollout(env: gym.Env, actions: Iterable[Any]) -> Rollout:
-    """Performs sequence of actions `actions` in `env`.
+    """Performs a sequence of actions `actions` in `env`.
 
     Args:
-      env: the environment to rollout in.
+      env: the environment to roll out in.
       actions: the actions to perform.
 
     Returns:

--- a/src/seals/testing/envs.py
+++ b/src/seals/testing/envs.py
@@ -99,7 +99,7 @@ def get_rollout(env: gym.Env, actions: Iterable[Any]) -> Rollout:
       A sequence of 5-tuples (obs, rew, terminated, truncated, info).
     """
     obs, info = env.reset()
-    ret: List[Step] = [(obs, 0, False, False, {})]
+    ret: List[Step] = [(obs, 0, False, False, info)]
     for act in actions:
         ret.append(env.step(act))
     return ret

--- a/src/seals/testing/envs.py
+++ b/src/seals/testing/envs.py
@@ -22,7 +22,8 @@ import numpy as np
 
 Step = Tuple[Any, Optional[float], bool, bool, Mapping[str, Any]]
 Rollout = Sequence[Step]
-"""A sequence of 4-tuples (obs, rew, terminated, truncated, info) as returned by `get_rollout`."""
+"""A sequence of 5-tuples (obs, rew, terminated, truncated, info) as returned by 
+`get_rollout`."""
 
 
 def make_env_fixture(
@@ -204,6 +205,7 @@ def _sample_and_check(env: gym.Env, obs_space: gym.Space) -> Tuple[bool, bool]:
 
 
 def is_mujoco_env(env: gym.Env) -> bool:
+    """True if `env` is a MuJoCo environment."""
     return hasattr(env, "sim") and hasattr(env, "model")
 
 

--- a/src/seals/testing/envs.py
+++ b/src/seals/testing/envs.py
@@ -203,7 +203,7 @@ def _sample_and_check(env: gym.Env, obs_space: gym.Space) -> Tuple[bool, bool]:
     assert isinstance(terminated, bool)
     assert isinstance(truncated, bool)
     assert isinstance(info, dict)
-    return terminated, truncated
+    return terminated or truncated
 
 
 def _is_mujoco_env(env: gym.Env) -> bool:
@@ -234,14 +234,14 @@ def test_rollout_schema(
     obs, _ = env.reset(seed=0)
     _check_obs(obs, obs_space)
 
-    terminated = False
+    done = False
     for _ in range(max_steps):
-        terminated, _ = _sample_and_check(env, obs_space)
-        if terminated:
+        done = _sample_and_check(env, obs_space)
+        if done:
             break
 
     if check_episode_ends:
-        assert terminated, "did not get to end of episode"
+        assert done, "did not get to end of episode"
 
         for _ in range(steps_after_terminated):
             _sample_and_check(env, obs_space)

--- a/src/seals/testing/envs.py
+++ b/src/seals/testing/envs.py
@@ -231,7 +231,7 @@ def test_rollout_schema(
         AssertionError if test fails.
     """
     obs_space = env.observation_space
-    obs, _ = env.reset()
+    obs, _ = env.reset(seed=0)
     _check_obs(obs, obs_space)
 
     terminated = False
@@ -289,7 +289,7 @@ def test_render(env: gym.Env, raises_fn) -> None:
             `env.metadata["render.modes"]` is empty; (c) `env.render(mode="rgb_array")`
             returns different values at the same time step.
     """
-    env.reset()  # make sure environment is in consistent state
+    env.reset(seed=0)  # make sure environment is in consistent state
 
     render_modes = env.metadata["render.modes"]
     if not render_modes:

--- a/src/seals/testing/envs.py
+++ b/src/seals/testing/envs.py
@@ -157,10 +157,7 @@ def test_seed(
     env.action_space.seed(0)
     actions = [env.action_space.sample() for _ in range(rollout_len)]
     # With the same seed, should always get the same result
-    seeds = env.reset(seed=42)
-    # output of env.seed should be a list, but atari environments return a tuple.
-    assert isinstance(seeds, (list, tuple))
-    assert len(seeds) > 0
+    env.reset(seed=42)
     rollout_a = get_rollout(env, actions)
 
     env.reset(seed=42)

--- a/src/seals/testing/envs.py
+++ b/src/seals/testing/envs.py
@@ -291,7 +291,7 @@ def test_render(env: gym.Env, raises_fn) -> None:
     """
     env.reset(seed=0)  # make sure environment is in consistent state
 
-    render_modes = env.metadata["render.modes"]
+    render_modes = env.metadata["render_modes"]
     if not render_modes:
         # No modes supported -- render() should fail.
         with raises_fn(NotImplementedError):

--- a/src/seals/testing/envs.py
+++ b/src/seals/testing/envs.py
@@ -22,7 +22,7 @@ import numpy as np
 
 Step = Tuple[Any, Optional[float], bool, bool, Mapping[str, Any]]
 Rollout = Sequence[Step]
-"""A sequence of 5-tuples (obs, rew, terminated, truncated, info) as returned by 
+"""A sequence of 5-tuples (obs, rew, terminated, truncated, info) as returned by
 `get_rollout`."""
 
 

--- a/src/seals/testing/envs.py
+++ b/src/seals/testing/envs.py
@@ -212,7 +212,7 @@ def _is_mujoco_env(env: gym.Env) -> bool:
 
 def test_rollout_schema(
     env: gym.Env,
-    steps_after_done: int = 10,
+    steps_after_terminated: int = 10,
     max_steps: int = 10_000,
     check_episode_ends: bool = True,
 ) -> None:
@@ -220,12 +220,12 @@ def test_rollout_schema(
 
     Args:
         env: The environment to test.
-        steps_after_done: The number of steps to take after `done` is True, the nominal
-            episode termination. This is an abuse of the Gym API, but we would like the
-            environments to handle this case gracefully.
-        max_steps: Test fails if we do not get `done` after this many timesteps.
+        steps_after_terminated: The number of steps to take after `terminated` is True,
+            the nominal episode termination. This is an abuse of the Gym API,
+            but we would like the environments to handle this case gracefully.
+        max_steps: Test fails if we do not get `terminated` after this many timesteps.
         check_episode_ends: Check that episode ends after `max_steps` steps, and that
-            steps taken after `done` is true are of the correct type.
+            steps taken after `terminated` is true are of the correct type.
 
     Raises:
         AssertionError if test fails.
@@ -243,7 +243,7 @@ def test_rollout_schema(
     if check_episode_ends:
         assert terminated, "did not get to end of episode"
 
-        for _ in range(steps_after_done):
+        for _ in range(steps_after_terminated):
             _sample_and_check(env, obs_space)
 
 

--- a/src/seals/util.py
+++ b/src/seals/util.py
@@ -168,8 +168,8 @@ class MaskScoreWrapper(
 
     def reset(self, **kwargs):
         """Returns masked reset observation."""
-        obs = self.env.reset(**kwargs)
-        return self._mask_obs(obs)
+        obs, info = self.env.reset(**kwargs)
+        return self._mask_obs(obs), info
 
 
 class ObsCastWrapper(gym.Wrapper):

--- a/src/seals/util.py
+++ b/src/seals/util.py
@@ -21,7 +21,7 @@ import numpy.typing as npt
 
 class AutoResetWrapper(
     gym.Wrapper,
-    Generic[WrapperObsType, WrapperActType, ObsType, ActType],
+    Generic[WrapperObsType, WrapperActType, ObsType, ActType],  # type: ignore
 ):
     """Hides terminated truncated and auto-resets at the end of each episode.
 
@@ -132,7 +132,7 @@ MaskedRegionSpecifier = List[BoxRegion]
 
 class MaskScoreWrapper(
     gym.Wrapper[npt.NDArray, ActType, npt.NDArray, ActType],
-    Generic[ActType],
+    Generic[ActType],  # type: ignore
 ):
     """Mask a list of box-shaped regions in the observation to hide reward info.
 

--- a/src/seals/util.py
+++ b/src/seals/util.py
@@ -188,9 +188,10 @@ class ObsCastWrapper(gym.Wrapper):
         super().__init__(env)
         self.dtype = dtype
 
-    def reset(self):
+    def reset(self, seed=None):
         """Returns reset observation, cast to self.dtype."""
-        return super().reset().astype(self.dtype)
+        obs, info = super().reset(seed=seed)
+        return obs.astype(self.dtype), info
 
     def step(self, action):
         """Returns (obs, rew, terminated, truncated, info) with obs cast to self.dtype."""

--- a/src/seals/util.py
+++ b/src/seals/util.py
@@ -146,7 +146,8 @@ class MaskScoreWrapper(
         super().__init__(env)
         self.fill_value = np.array(fill_value, env.observation_space.dtype)
 
-        assert env.observation_space.shape is not None
+        if env.observation_space.shape is None:
+            raise ValueError("Observation space must have a shape.")
         self.mask = np.ones(env.observation_space.shape, dtype=bool)
         for r in score_regions:
             if r.x[0] >= r.x[1] or r.y[0] >= r.y[1]:

--- a/src/seals/util.py
+++ b/src/seals/util.py
@@ -275,14 +275,6 @@ class AbsorbAfterDoneWrapper(gym.Wrapper):
         return obs, rew, False, False, info
 
 
-def make_env_no_wrappers(env_name: str, **kwargs) -> gym.Env:
-    """Gym sometimes wraps envs in TimeLimit before returning from gymnasium.make().
-
-    This helper method builds directly from spec to avoid this wrapper.
-    """
-    return gym.spec(env_name).make(**kwargs)
-
-
 def get_gym_max_episode_steps(env_name: str) -> Optional[int]:
     """Get the `max_episode_steps` attribute associated with a gym Spec."""
     return gym.spec(env_name).max_episode_steps

--- a/src/seals/util.py
+++ b/src/seals/util.py
@@ -171,7 +171,7 @@ class MaskScoreWrapper(
         self.fill_value = np.array(fill_value, env.observation_space.dtype)
 
         if env.observation_space.shape is None:
-            raise ValueError("Observation space must have a shape.")
+            raise ValueError("Observation space must have a shape.")  # pragma: no cover
         self.mask = np.ones(env.observation_space.shape, dtype=bool)
         for r in score_regions:
             if r.x[0] >= r.x[1] or r.y[0] >= r.y[1]:

--- a/src/seals/util.py
+++ b/src/seals/util.py
@@ -20,7 +20,8 @@ import numpy.typing as npt
 
 
 class AutoResetWrapper(
-    gym.Wrapper, Generic[WrapperObsType, WrapperActType, ObsType, ActType],
+    gym.Wrapper,
+    Generic[WrapperObsType, WrapperActType, ObsType, ActType],
 ):
     """Hides terminated truncated and auto-resets at the end of each episode.
 
@@ -52,7 +53,8 @@ class AutoResetWrapper(
         self.previous_done = False  # Whether the previous step returned done=True.
 
     def step(
-        self, action: WrapperActType,
+        self,
+        action: WrapperActType,
     ) -> Tuple[ObsType, SupportsFloat, bool, bool, Dict[str, Any]]:
         """When terminated or truncated, resets the environment.
 
@@ -69,7 +71,8 @@ class AutoResetWrapper(
             return self._step_pad(action)
 
     def _step_pad(
-        self, action: WrapperActType,
+        self,
+        action: WrapperActType,
     ) -> Tuple[ObsType, SupportsFloat, bool, bool, Dict[str, Any]]:
         """When terminated or truncated, resets the environment.
 
@@ -99,7 +102,8 @@ class AutoResetWrapper(
         return obs, rew, False, False, info
 
     def _step_discard(
-        self, action: WrapperActType,
+        self,
+        action: WrapperActType,
     ) -> Tuple[ObsType, SupportsFloat, bool, bool, Dict[str, Any]]:
         """When terminated or truncated, return False for both and automatically reset.
 
@@ -171,7 +175,8 @@ class MaskScoreWrapper(
         return np.where(self.mask, obs, self.fill_value)
 
     def step(
-        self, action: ActType,
+        self,
+        action: ActType,
     ) -> Tuple[npt.NDArray, SupportsFloat, bool, bool, Dict[str, Any]]:
         """Returns (obs, rew, terminated, truncated, info) with masked obs."""
         obs, rew, terminated, truncated, info = self.env.step(action)

--- a/src/seals/util.py
+++ b/src/seals/util.py
@@ -1,7 +1,7 @@
 """Miscellaneous utilities."""
 
 from dataclasses import dataclass
-from typing import Any, Generic, List, Optional, Sequence, SupportsFloat, Tuple, Union
+from typing import Any, Generic, List, Optional, Sequence, SupportsFloat, Tuple, Union, Dict
 
 import gymnasium as gym
 import numpy as np
@@ -43,7 +43,7 @@ class AutoResetWrapper(
 
     def step(
         self, action: WrapperActType
-    ) -> tuple[ObsType, SupportsFloat, bool, bool, dict[str, Any]]:
+    ) -> Tuple[ObsType, SupportsFloat, bool, bool, Dict[str, Any]]:
         """When done=True, returns done=False, then reset depending on flag.
 
         Depending on whether we are discarding the terminal observation,
@@ -58,7 +58,7 @@ class AutoResetWrapper(
 
     def _step_pad(
         self, action: WrapperActType
-    ) -> tuple[ObsType, SupportsFloat, bool, bool, dict[str, Any]]:
+    ) -> Tuple[ObsType, SupportsFloat, bool, bool, Dict[str, Any]]:
         """When done=True, return done=False instead and return the terminal obs.
 
         The agent will then usually be asked to perform an action based on
@@ -87,7 +87,7 @@ class AutoResetWrapper(
 
     def _step_discard(
         self, action: WrapperActType
-    ) -> tuple[ObsType, SupportsFloat, bool, bool, dict[str, Any]]:
+    ) -> Tuple[ObsType, SupportsFloat, bool, bool, Dict[str, Any]]:
         """When done=True, returns done=False instead and automatically resets.
 
         When an automatic reset happens, the observation from reset is returned,
@@ -158,7 +158,7 @@ class MaskScoreWrapper(
 
     def step(
         self, action: ActType
-    ) -> tuple[npt.NDArray, SupportsFloat, bool, bool, dict[str, Any]]:
+    ) -> Tuple[npt.NDArray, SupportsFloat, bool, bool, Dict[str, Any]]:
         """Returns (obs, rew, terminated, truncated, info) with masked obs."""
         obs, rew, terminated, truncated, info = self.env.step(action)
         return self._mask_obs(obs), rew, terminated, truncated, info

--- a/src/seals/util.py
+++ b/src/seals/util.py
@@ -10,18 +10,25 @@ from typing import (
     Sequence,
     SupportsFloat,
     Tuple,
+    TypeVar,
     Union,
 )
 
 import gymnasium as gym
-from gymnasium.core import ActType, ObsType, WrapperActType, WrapperObsType
 import numpy as np
 import numpy.typing as npt
+
+# Note: we redefine the type vars from gymnasium.core here, because pytype does not
+# recognize them as valid type vars if we import them from gymnasium.core.
+WrapperObsType = TypeVar("WrapperObsType")
+WrapperActType = TypeVar("WrapperActType")
+ObsType = TypeVar("ObsType")
+ActType = TypeVar("ActType")
 
 
 class AutoResetWrapper(
     gym.Wrapper,
-    Generic[WrapperObsType, WrapperActType, ObsType, ActType],  # type: ignore
+    Generic[WrapperObsType, WrapperActType, ObsType, ActType],
 ):
     """Hides terminated truncated and auto-resets at the end of each episode.
 
@@ -132,7 +139,7 @@ MaskedRegionSpecifier = List[BoxRegion]
 
 class MaskScoreWrapper(
     gym.Wrapper[npt.NDArray, ActType, npt.NDArray, ActType],
-    Generic[ActType],  # type: ignore
+    Generic[ActType],
 ):
     """Mask a list of box-shaped regions in the observation to hide reward info.
 

--- a/src/seals/util.py
+++ b/src/seals/util.py
@@ -195,7 +195,7 @@ class MaskScoreWrapper(
         return self._mask_obs(obs), info
 
 
-class ObsCastWrapper(gym.Wrapper):
+class ObsCastWrapper(gym.ObservationWrapper):
     """Cast observations to specified dtype.
 
     Some external environments return observations of a different type than the
@@ -214,15 +214,9 @@ class ObsCastWrapper(gym.Wrapper):
         super().__init__(env)
         self.dtype = dtype
 
-    def reset(self, seed=None):
-        """Returns reset observation, cast to self.dtype."""
-        obs, info = super().reset(seed=seed)
-        return obs.astype(self.dtype), info
-
-    def step(self, action):
-        """Returns (obs, rew, terminated, truncated, info) with obs cast to dtype."""
-        obs, rew, terminated, truncated, info = super().step(action)
-        return obs.astype(self.dtype), rew, terminated, truncated, info
+    def observation(self, obs):
+        """Returns observation cast to self.dtype."""
+        return obs.astype(self.dtype)
 
 
 class AbsorbAfterDoneWrapper(gym.Wrapper):

--- a/src/seals/util.py
+++ b/src/seals/util.py
@@ -22,8 +22,7 @@ import numpy.typing as npt
 class AutoResetWrapper(
     gym.Wrapper, Generic[WrapperObsType, WrapperActType, ObsType, ActType],
 ):
-    """Hides terminated=True and truncated=True and auto-resets at the end of each
-    episode.
+    """Hides terminated truncated and auto-resets at the end of each episode.
 
     Depending on the flag 'discard_terminal_observation', either discards the terminal
     observation or pads with an additional 'reset transition'. The former is the default
@@ -55,8 +54,9 @@ class AutoResetWrapper(
     def step(
         self, action: WrapperActType,
     ) -> Tuple[ObsType, SupportsFloat, bool, bool, Dict[str, Any]]:
-        """When terminated or truncated, resets the environment and returns False
-        for terminated and truncated.
+        """When terminated or truncated, resets the environment.
+
+        Always returns False for terminated and truncated.
 
         Depending on whether we are discarding the terminal observation,
         either resets the environment and discards,
@@ -71,8 +71,9 @@ class AutoResetWrapper(
     def _step_pad(
         self, action: WrapperActType,
     ) -> Tuple[ObsType, SupportsFloat, bool, bool, Dict[str, Any]]:
-        """When terminated or truncated, return False for both instead and return the
-        terminal obs.
+        """When terminated or truncated, resets the environment.
+
+        Always returns False for terminated and truncated.
 
         The agent will then usually be asked to perform an action based on
         the terminal observation. In the next step, this final action will be ignored
@@ -207,7 +208,7 @@ class ObsCastWrapper(gym.Wrapper):
         return obs.astype(self.dtype), info
 
     def step(self, action):
-        """Returns (obs, rew, terminated, truncated, info) with obs cast to self.dtype."""
+        """Returns (obs, rew, terminated, truncated, info) with obs cast to dtype."""
         obs, rew, terminated, truncated, info = super().step(action)
         return obs.astype(self.dtype), rew, terminated, truncated, info
 

--- a/src/seals/util.py
+++ b/src/seals/util.py
@@ -1,12 +1,22 @@
 """Miscellaneous utilities."""
 
 from dataclasses import dataclass
-from typing import Any, Generic, List, Optional, Sequence, SupportsFloat, Tuple, Union, Dict
+from typing import (
+    Any,
+    Dict,
+    Generic,
+    List,
+    Optional,
+    Sequence,
+    SupportsFloat,
+    Tuple,
+    Union,
+)
 
 import gymnasium as gym
+from gymnasium.core import ActType, ObsType, WrapperActType, WrapperObsType
 import numpy as np
 import numpy.typing as npt
-from gymnasium.core import ActType, ObsType, WrapperActType, WrapperObsType
 
 
 class AutoResetWrapper(

--- a/src/seals/util.py
+++ b/src/seals/util.py
@@ -249,28 +249,26 @@ class AbsorbAfterDoneWrapper(gym.Wrapper):
         `rew` depend on initialization arguments. `info` is always an empty dictionary.
         """
         if not self.at_absorb_state:
-            inner_obs, inner_rew, terminated, truncated, inner_info = self.env.step(
+            obs, rew, terminated, truncated, info = self.env.step(
                 action
             )
-            if terminated:
+            if terminated or truncated:
                 # Initialize the artificial absorb state, which we will repeatedly use
                 # starting on the next call to `step()`.
                 self.at_absorb_state = True
 
                 if self.absorb_obs_default is None:
-                    self.absorb_obs_this_episode = inner_obs
+                    self.absorb_obs_this_episode = obs
                 else:
                     self.absorb_obs_this_episode = self.absorb_obs_default
-            obs, rew, info = inner_obs, inner_rew, inner_info
         else:
             assert self.absorb_obs_this_episode is not None
             assert self.absorb_reward is not None
             obs = self.absorb_obs_this_episode
             rew = self.absorb_reward
             info = {}
-            truncated = False
 
-        return obs, rew, False, truncated, info
+        return obs, rew, False, False, info
 
 
 def make_env_no_wrappers(env_name: str, **kwargs) -> gym.Env:

--- a/src/seals/util.py
+++ b/src/seals/util.py
@@ -20,7 +20,7 @@ import numpy.typing as npt
 
 
 class AutoResetWrapper(
-    gym.Wrapper, Generic[WrapperObsType, WrapperActType, ObsType, ActType]
+    gym.Wrapper, Generic[WrapperObsType, WrapperActType, ObsType, ActType],
 ):
     """Hides terminated=True and truncated=True and auto-resets at the end of each
     episode.
@@ -53,7 +53,7 @@ class AutoResetWrapper(
         self.previous_done = False  # Whether the previous step returned done=True.
 
     def step(
-        self, action: WrapperActType
+        self, action: WrapperActType,
     ) -> Tuple[ObsType, SupportsFloat, bool, bool, Dict[str, Any]]:
         """When terminated or truncated, resets the environment and returns False
         for terminated and truncated.
@@ -69,7 +69,7 @@ class AutoResetWrapper(
             return self._step_pad(action)
 
     def _step_pad(
-        self, action: WrapperActType
+        self, action: WrapperActType,
     ) -> Tuple[ObsType, SupportsFloat, bool, bool, Dict[str, Any]]:
         """When terminated or truncated, return False for both instead and return the
         terminal obs.
@@ -98,7 +98,7 @@ class AutoResetWrapper(
         return obs, rew, False, False, info
 
     def _step_discard(
-        self, action: WrapperActType
+        self, action: WrapperActType,
     ) -> Tuple[ObsType, SupportsFloat, bool, bool, Dict[str, Any]]:
         """When terminated or truncated, return False for both and automatically reset.
 
@@ -170,7 +170,7 @@ class MaskScoreWrapper(
         return np.where(self.mask, obs, self.fill_value)
 
     def step(
-        self, action: ActType
+        self, action: ActType,
     ) -> Tuple[npt.NDArray, SupportsFloat, bool, bool, Dict[str, Any]]:
         """Returns (obs, rew, terminated, truncated, info) with masked obs."""
         obs, rew, terminated, truncated, info = self.env.step(action)
@@ -263,9 +263,7 @@ class AbsorbAfterDoneWrapper(gym.Wrapper):
         `info` is always an empty dictionary.
         """
         if not self.at_absorb_state:
-            obs, rew, terminated, truncated, info = self.env.step(
-                action
-            )
+            obs, rew, terminated, truncated, info = self.env.step(action)
             if terminated or truncated:
                 # Initialize the artificial absorb state, which we will repeatedly use
                 # starting on the next call to `step()`.

--- a/tests/test_base_env.py
+++ b/tests/test_base_env.py
@@ -7,6 +7,7 @@ so the tests in this file focus on features unique to classes in `base_envs`.
 import gymnasium as gym
 import numpy as np
 import pytest
+
 from seals import base_envs
 from seals.testing import envs
 

--- a/tests/test_base_env.py
+++ b/tests/test_base_env.py
@@ -17,6 +17,7 @@ class NewEnv(base_envs.TabularModelMDP):
 
     def __init__(self):
         """Build environment."""
+        np.random.seed(0)
         nS = 3
         nA = 2
         transition_matrix = np.random.random((nS, nA, nS))

--- a/tests/test_base_env.py
+++ b/tests/test_base_env.py
@@ -4,10 +4,9 @@ Note base_envs is also tested indirectly via smoke tests in `test_envs`,
 so the tests in this file focus on features unique to classes in `base_envs`.
 """
 
-import gym
+import gymnasium as gym
 import numpy as np
 import pytest
-
 from seals import base_envs
 from seals.testing import envs
 
@@ -19,9 +18,9 @@ class NewEnv(base_envs.TabularModelMDP):
         """Build environment."""
         nS = 3
         nA = 2
-        transition_matrix = np.random.rand(nS, nA, nS)
+        transition_matrix = np.random.random((nS, nA, nS))
         transition_matrix /= transition_matrix.sum(axis=2)[:, :, None]
-        reward_matrix = np.random.rand(nS)
+        reward_matrix = np.random.random((nS,))
         super().__init__(
             transition_matrix=transition_matrix,
             reward_matrix=reward_matrix,

--- a/tests/test_base_env.py
+++ b/tests/test_base_env.py
@@ -102,7 +102,7 @@ def test_expose_pomdp_state_wrapper():
     assert state in env.state_space
 
     action = env.action_space.sample()
-    next_state, reward, done, info = wrapped_env.step(action)
+    next_state, reward, terminated, truncated, info = wrapped_env.step(action)
     assert next_state == env.state
     assert next_state in env.state_space
 

--- a/tests/test_base_env.py
+++ b/tests/test_base_env.py
@@ -52,6 +52,9 @@ def test_base_envs():
     with pytest.raises(ValueError, match=r".*not in.*"):
         env.state = bad_state  # type: ignore
 
+    with pytest.raises(NotImplementedError, match=r"Options not supported.*"):
+        env.reset(options={"option": "value"})
+
 
 def test_tabular_env_validation():
     """Test input validation for base_envs.TabularModelEnv."""

--- a/tests/test_base_env.py
+++ b/tests/test_base_env.py
@@ -35,7 +35,7 @@ def test_base_envs():
 
     envs.test_premature_step(env, skip_fn=pytest.skip, raises_fn=pytest.raises)
 
-    env.reset()
+    env.reset(seed=0)
     assert env.n_actions_taken == 0
     env.step(env.action_space.sample())
     assert env.n_actions_taken == 1
@@ -86,7 +86,7 @@ def test_tabular_env_validation():
         transition_matrix=np.zeros((3, 1, 3)),
         reward_matrix=np.zeros((3,)),
     )
-    env.reset()
+    env.reset(seed=0)
     with pytest.raises(ValueError, match=r".*not in.*"):
         env.step(4)
 
@@ -97,7 +97,7 @@ def test_expose_pomdp_state_wrapper():
     wrapped_env = base_envs.ExposePOMDPStateWrapper(env)
 
     assert wrapped_env.observation_space == env.state_space
-    state = wrapped_env.reset()
+    state, _ = wrapped_env.reset(seed=0)
     assert state == env.state
     assert state in env.state_space
 

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -10,9 +10,8 @@ from seals.atari import SCORE_REGIONS, _get_score_region, _seals_name, make_atar
 from seals.testing import envs
 
 ENV_NAMES: List[str] = [
-    env_spec.id
-    for env_spec in registration.registry.values()
-    if env_spec.id.startswith("seals/")
+    env_id for env_id in registration.registry.keys()
+    if env_id.startswith("seals/")
 ]
 
 

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -120,6 +120,7 @@ class TestEnvs:
                 "seals/KingKong-Unmasked-v5",
                 "seals/Koolaid-Unmasked-v5",
                 "seals/NameThisGame-Unmasked-v5",
+                "seals/Casino-Unmasked-v5",
             ]
             rollout_len = 100 if env_name not in slow_random_envs else 400
             num_seeds = 2 if env_name in ATARI_NO_FRAMESKIP_ENVS else 10

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -3,10 +3,11 @@
 from typing import List
 
 import gymnasium as gym
+from gymnasium.envs import registration
 import numpy as np
 import pytest
+
 import seals  # noqa: F401 required for env registration
-from gymnasium.envs import registration
 from seals.atari import SCORE_REGIONS, _get_score_region, _seals_name, make_atari_env
 from seals.testing import envs
 from seals.testing.envs import is_mujoco_env

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -1,6 +1,6 @@
 """Smoke tests for all environments."""
 
-from typing import List
+from typing import List, Union
 
 import gymnasium as gym
 from gymnasium.envs import registration
@@ -165,8 +165,10 @@ class TestEnvs:
             if mode == "rgb_array" and not is_mujoco_env(env):
                 # The render should not change without calling `step()`.
                 # MuJoCo rendering fails this check, ignore -- not much we can do.
-                r1 = env.render()
-                r2 = env.render()
+                r1: Union[np.ndarray, List[np.ndarray], None] = env.render()
+                r2: Union[np.ndarray, List[np.ndarray], None] = env.render()
+                assert r1 is not None
+                assert r2 is not None
                 assert np.allclose(r1, r2)
             else:
                 env.render()

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -11,7 +11,7 @@ from seals.testing import envs
 
 ENV_NAMES: List[str] = [
     env_spec.id
-    for env_spec in registration.registry.all()
+    for env_spec in registration.registry.values()
     if env_spec.id.startswith("seals/")
 ]
 

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -2,11 +2,10 @@
 
 from typing import List
 
-import gym
-from gym.envs import registration
+import gymnasium as gym
 import pytest
-
 import seals  # noqa: F401 required for env registration
+from gymnasium.envs import registration
 from seals.atari import SCORE_REGIONS, _get_score_region, _seals_name, make_atari_env
 from seals.testing import envs
 

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -13,8 +13,7 @@ from seals.testing import envs
 from seals.testing.envs import is_mujoco_env
 
 ENV_NAMES: List[str] = [
-    env_id for env_id in registration.registry.keys()
-    if env_id.startswith("seals/")
+    env_id for env_id in registration.registry.keys() if env_id.startswith("seals/")
 ]
 
 

--- a/tests/test_mujoco_rl.py
+++ b/tests/test_mujoco_rl.py
@@ -2,7 +2,7 @@
 
 from typing import Tuple
 
-import gym
+import gymnasium as gym
 import pytest
 import stable_baselines3
 from stable_baselines3.common import evaluation

--- a/tests/test_mujoco_rl.py
+++ b/tests/test_mujoco_rl.py
@@ -35,9 +35,9 @@ def test_fixed_env_model_as_good_as_gym_env_model(env_base: str):  # pragma: no 
     """Compare original and modified MuJoCo v3 envs."""
     train_timesteps = 200000
 
-    gym_reward, _ = _eval_env(f"{env_base}-v3", total_timesteps=train_timesteps)
+    gym_reward, _ = _eval_env(f"{env_base}-v4", total_timesteps=train_timesteps)
     fixed_reward, _ = _eval_env(
-        f"seals/{env_base}-v0",
+        f"seals/{env_base}-v1",
         total_timesteps=train_timesteps,
     )
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -5,6 +5,7 @@ import collections
 import gymnasium as gym
 import numpy as np
 import pytest
+
 from seals import GYM_ATARI_ENV_SPECS, util
 
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -21,13 +21,12 @@ def test_mask_score_wrapper_enforces_spec():
 
 def test_sample_distribution():
     """Test util.sample_distribution."""
-    np.random.seed(0)
     distr_size = 5
     distr = np.random.random((distr_size,))
     distr /= distr.sum()
 
     n_samples = 1000
-    rng = np.random.default_rng()
+    rng = np.random.default_rng(0)
     sample_count = collections.Counter(
         util.sample_distribution(distr, rng) for _ in range(n_samples)
     )

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -20,6 +20,7 @@ def test_mask_score_wrapper_enforces_spec():
 
 def test_sample_distribution():
     """Test util.sample_distribution."""
+    np.random.seed(0)
     distr_size = 5
     distr = np.random.random((distr_size,))
     distr /= distr.sum()

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -2,10 +2,9 @@
 
 import collections
 
-import gym
+import gymnasium as gym
 import numpy as np
 import pytest
-
 from seals import GYM_ATARI_ENV_SPECS, util
 
 
@@ -22,11 +21,11 @@ def test_mask_score_wrapper_enforces_spec():
 def test_sample_distribution():
     """Test util.sample_distribution."""
     distr_size = 5
-    distr = np.random.rand(distr_size)
+    distr = np.random.random((distr_size,))
     distr /= distr.sum()
 
     n_samples = 1000
-    rng = np.random.RandomState()
+    rng = np.random.default_rng()
     sample_count = collections.Counter(
         util.sample_distribution(distr, rng) for _ in range(n_samples)
     )
@@ -39,8 +38,8 @@ def test_sample_distribution():
 
     # Same seed gives same samples
     assert all(
-        util.sample_distribution(distr, random=np.random.RandomState(seed))
-        == util.sample_distribution(distr, random=np.random.RandomState(seed))
+        util.sample_distribution(distr, random=np.random.default_rng(seed))
+        == util.sample_distribution(distr, random=np.random.default_rng(seed))
         for seed in range(20)
     )
 

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -22,7 +22,7 @@ def test_auto_reset_wrapper_pad(episode_length=3, n_steps=100, n_manual_reset=2)
     )
 
     for _ in range(n_manual_reset):
-        obs = env.reset()
+        obs, info = env.reset()
         assert obs == 0
 
         # We count the number of episodes, so we can sanity check the padding.
@@ -75,7 +75,7 @@ def test_auto_reset_wrapper_discard(episode_length=3, n_steps=100, n_manual_rese
     )
 
     for _ in range(n_manual_reset):
-        obs = env.reset()
+        obs, info = env.reset()
         assert obs == 0
 
         for t in range(1, n_steps + 1):
@@ -159,7 +159,7 @@ def test_obs_cast(dtype: np.dtype, episode_length: int = 5):
     env = envs.CountingEnv(episode_length=episode_length)
     env = util.ObsCastWrapper(env, dtype)
 
-    obs = env.reset()
+    obs, info = env.reset()
     assert obs.dtype == dtype
     assert obs == 0
     for t in range(1, episode_length + 1):

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 import pytest
+
 from seals import util
 from seals.testing import envs
 

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -13,9 +13,9 @@ def test_auto_reset_wrapper_pad(episode_length=3, n_steps=100, n_manual_reset=2)
     AutoResetWrapper that pads trajectory with an extra transition containing the
     terminal observations.
     Also check that calls to .reset() do not interfere with automatic resets.
-    Due to the padding, the number of steps counted inside the environment and the number
-    of steps performed outside the environment, i.e., the number of actions performed,
-    will differ. This test checks that this difference is consistent.
+    Due to the padding, the number of steps counted inside the environment and the
+    number of steps performed outside the environment, i.e., the number of actions
+    performed, will differ. This test checks that this difference is consistent.
     """
     env = util.AutoResetWrapper(
         envs.CountingEnv(episode_length=episode_length),

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -12,8 +12,8 @@ def test_auto_reset_wrapper_pad(episode_length=3, n_steps=100, n_manual_reset=2)
     AutoResetWrapper that pads trajectory with an extra transition containing the
     terminal observations.
     Also check that calls to .reset() do not interfere with automatic resets.
-    Due to the padding the number of steps counted inside the environment and the number
-    of steps performed outside the environment, i.e. the number of actions performed,
+    Due to the padding, the number of steps counted inside the environment and the number
+    of steps performed outside the environment, i.e., the number of actions performed,
     will differ. This test checks that this difference is consistent.
     """
     env = util.AutoResetWrapper(

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -32,7 +32,7 @@ def test_auto_reset_wrapper_pad(episode_length=3, n_steps=100, n_manual_reset=2)
             act = env.action_space.sample()
             obs, rew, terminated, truncated, info = env.step(act)
 
-            # AutoResetWrapper overrides all done signals.
+            # AutoResetWrapper overrides all terminated and truncated signals.
             assert terminated is False
             assert truncated is False
 

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -157,8 +157,10 @@ def test_obs_cast(dtype: np.dtype, episode_length: int = 5):
     Test uses CountingEnv with small integers, which can be represented in
     all the specified dtypes without any loss of precision.
     """
-    env = envs.CountingEnv(episode_length=episode_length)
-    env = util.ObsCastWrapper(env, dtype)
+    env = util.ObsCastWrapper(
+        envs.CountingEnv(episode_length=episode_length),
+        dtype,
+    )
 
     obs, info = env.reset()
     assert obs.dtype == dtype

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -162,7 +162,7 @@ def test_obs_cast(dtype: np.dtype, episode_length: int = 5):
         dtype,
     )
 
-    obs, info = env.reset()
+    obs, _ = env.reset()
     assert obs.dtype == dtype
     assert obs == 0
     for t in range(1, episode_length + 1):


### PR DESCRIPTION
## Description

Continuing the work in #72 
- reverted incompatible  > python3.9 changes
- primarily changes for compatibility with (https://github.com/HumanCompatibleAI/imitation/pull/765)
- further changes to environments `reset`, `step` and random functions. 
- Update to Ubuntu 20.04
- Upgraded from the MuJoCo-v3 to the v4 environments bumping their corresponding seals version along the way.

- [ ] Rename the circleci docker image (remove -beta suffix)

## Testing 
Some test have been refactored. Mostly the rendering tests.
